### PR TITLE
add support for relative symlinks to blank tiles in mapcache

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -400,6 +400,7 @@ struct mapcache_cache_disk {
     char *base_directory;
     char *filename_template;
     int symlink_blank;
+    int symlink_rel;
     int creation_retry;
 
     /**


### PR DESCRIPTION
currently symlinks to blank tiles are absolute. If the disk mountpoint changes all these links will be invalid. this pull request adds support for relative symlinks, and makes it a configurable option by adding the attribute linking to the `<symlink_blank/>` tag. Valid values are relative and absolute, the attribute is optional and defaults to absolute.

``` xml
<cache name="disk-cache" type="disk">
   <base>/path/to/cache</base>
   <!--
      New option linking, optional, valid values are relative or absolute, default is absolute.
   -->
   <symlink_blank linking="relative"/>
</cache>
```

might be good to keep it configurable, relative symlink support might differ between filesystems (just a guess...)

the char buffer created for the relative path is 255 chars at the moment. if the resulting relative path is longer it will return with error. Should be more than enough i think, the path will mostly consist of a bunch of concatenated `../`
