### PR TITLE
mapcache_seed hangs in extract mode if it encounters zoom levels with no tiles

### DIFF
--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -406,7 +406,7 @@ cmd examine_tile(mapcache_context *ctx, mapcache_tile *tile)
     }
   } else {
     // the tile does not exist
-    if(mode == MAPCACHE_CMD_SEED || mode == MAPCACHE_CMD_TRANSFER) {
+    if(mode == MAPCACHE_CMD_SEED) {
 #ifdef USE_CLIPPERS
       /* check we are in the requested features before deleting the tile */
       if(nClippers > 0) {
@@ -629,14 +629,16 @@ void seed_worker()
         mapcache_unlock_resource(&seed_ctx, mapcache_tileset_metatile_resource_key(&seed_ctx,mt));
       }
     } else if (cmd.command == MAPCACHE_CMD_TRANSFER) {
-      int i;
+      int i,get_ret;
       mapcache_metatile *mt = mapcache_tileset_metatile_get(&seed_ctx, tile);
       for (i = 0; i < mt->ntiles; i++) {
         mapcache_tile *subtile = &mt->tiles[i];
-        mapcache_tileset_tile_get(&seed_ctx, subtile);
+        get_ret = subtile->tileset->cache->tile_get(&seed_ctx,subtile);
         if(GC_HAS_ERROR(&seed_ctx)) break;
-        subtile->tileset = tileset_transfer;
-        tileset_transfer->cache->tile_set(&seed_ctx, subtile);
+        if(get_ret == MAPCACHE_SUCCESS) {
+          subtile->tileset = tileset_transfer;
+          tileset_transfer->cache->tile_set(&seed_ctx, subtile);
+        }
       }
     } else { //CMD_DELETE
       mapcache_tileset_tile_delete(&seed_ctx,tile,MAPCACHE_TRUE);


### PR DESCRIPTION
We've been using mapcache_seed to create small subsets of large caches using the extract mode.  It seems that if it encounters a zoom level in the source cache that doesn't have tiles, it hangs.

Our process is like this:

Seed tileset "test" to level 17 in an mbtiles cache (not sure if cache type matters, probably not):
mapcache_seed -c mapcache.xml -t test -g g -z 0,17 -n 4 -d /mnt/map/data/other/aoi.shp -l aoi

Move test.db to a server that only serves tiles, doesn't create them.

Transfer test to test2 (also mbtiles) for a given bbox.  Mapcache.xml used for transferring doesn't have a source mapfile for either "test" or "test2" as we don't want this server to render tiles:
mapcache_seed -c mapcache.xml -t test2 -g g -z 0,16 -n 4 -m transfer -x test -e -8595344.000000,5583572.000000,-8554068.000000,5624848.000000

In the case of our source (i.e. "test" tileset) was generated for a restricted area and the bbox for the transfer includes areas that are not within aoi.shp.  Therefore at some zoom level, there were no tiles generated for parts of the bbox.

The error that was returned by  mapcache_seed was: mbtiles backend failed on image set: SQL logic error or missing database (1)
