### PR TITLE
mapcache_seed segfault when using threading

### DIFF
--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -606,9 +606,11 @@ void seed_worker()
 {
   mapcache_tile *tile;
   mapcache_context seed_ctx = ctx;
+  apr_pool_t *tpool;
   seed_ctx.log = seed_log;
   apr_pool_create(&seed_ctx.pool,ctx.pool);
-  tile = mapcache_tileset_tile_create(ctx.pool, tileset, grid_link);
+  apr_pool_create(&tpool,ctx.pool);
+  tile = mapcache_tileset_tile_create(tpool, tileset, grid_link);
   tile->dimensions = dimensions;
   while(1) {
     struct seed_cmd cmd;


### PR DESCRIPTION
mapcache_seed is halting with "segmentation fault (core dumped)" when using any number of threads > 1. 

Setup as follows:

Hardware:
- Power Edge R820, 4-socket, 2U blade server
- Populated with four Intel Xeon E5 processors
- Processor E5-4650L - 20M Cache, 2.60 GHz, 8.00 GT/s), Clock Speed2.6 GHz. Max
- Turbo Frequency 3.1 GHz,
- Each processor has 8 (microprocessor) cores,
- Supporting 16 threads per core with hyper threading,
- A total of 64 threads, and
- 300GB RAM. (48 DIMMS (upgradable to 1.5 TB of memory))

OS:
- Red Hat Enterprise Linux Server release 6.3 (Santiago)

Software:
- Apache Server version: Apache/2.2.15 (Unix)
  - mod_wsgi
  - mod_mapcache
- MapServer 6.0.3
- MapCache (current devel 6.2.0beta2)
- Gdal 1.8.1
- Python 2.6.6
  - Python Mapscript
- Perl 5.10.1
  - Perl Mapscript
- Postgres 8.4.12/PostGIS 1.5.3

Please see the following thread for more information:
http://osgeo-org.1560.n6.nabble.com/mapcache-seed-segfault-when-using-threading-SEC-UNCLASSIFIED-td5007582.html

Backtrace is as follows:

```
$ ulimit -c unlimited  (to ensure the core was dumped) 
$ /mapcache/bin/mapcache_seed -c /mapcache/config/meteye_test.xml -t IDZ71000 -M 8,8 -n 32 -g AUS -z 0,4 -d /mapcache/data/adfd_active_area.shp -D "TIMESTEP=5" -D "NOWTIME=201210221900" 
Segmentation fault (core dumped) 
$ gdb -c core.5808 mapcache_seed 
(gdb) bt 

#0  0x00007fdb313da786 in apr_palloc () from /usr/lib64/libapr-1.so.0 
#1  0x00007fdb313d0b0c in apr_pstrdup () from /usr/lib64/libapr-1.so.0 
#2  0x00007fdb313d25fe in apr_table_set () from /usr/lib64/libapr-1.so.0 
#3  0x00007fdb315f991d in mapcache_tileset_tile_create (pool=0x1ad0b98, tileset=0x1b0da30, grid_link=0x1b0dc48) at tileset.c:530 
#4  0x00000000004039e3 in seed_worker () at mapcache_seed.c:611 
#5  0x0000000000403c62 in seed_thread (thread=0x7fdac4002ec0, data=0x0) at mapcache_seed.c:658 
#6  0x00000035cb807851 in start_thread () from /lib64/libpthread.so.0 
#7  0x00000035cb0e76dd in clone () from /lib64/libc.so.6 
```
