### PR TITLE
improvements/changes

### DIFF
--- a/lib/core.c
+++ b/lib/core.c
@@ -597,6 +597,7 @@ mapcache_http_response* mapcache_core_respond_to_error(mapcache_context *ctx)
     response->data->avail = response->data->size;
   } else if(ctx->config && ctx->config->reporting == MAPCACHE_REPORT_EMPTY_IMG) {
     response->data = ctx->config->empty_image;
+    response->code = 200;
     apr_table_set(response->headers, "Content-Type", ctx->config->default_image_format->mime_type);
     apr_table_set(response->headers, "X-Mapcache-Error", msg);
   } else if(ctx->config && ctx->config->reporting == MAPCACHE_REPORT_ERROR_IMG) {

--- a/lib/core.c
+++ b/lib/core.c
@@ -448,7 +448,8 @@ mapcache_http_response *mapcache_core_get_map(mapcache_context *ctx, mapcache_re
   }
 
   if(basemap->raw_image) {
-    format = req_map->getmap_format; /* always defined, defaults to JPEG */
+    //format = req_map->getmap_format; /* always defined, defaults to JPEG */
+    format = ctx->config->default_image_format; //default format from configuration file
     response->data = format->write(ctx,basemap->raw_image,format);
     if(GC_HAS_ERROR(ctx)) {
       return NULL;

--- a/lib/imageio_jpeg.c
+++ b/lib/imageio_jpeg.c
@@ -194,17 +194,25 @@ mapcache_buffer* _mapcache_imageio_jpeg_encode(mapcache_context *ctx, mapcache_i
   for(row=0; row<img->h; row++) {
     JSAMPLE *pixptr = rowdata;
     int col;
-    unsigned char *r,*g,*b;
+    unsigned char *r,*g,*b,*alpha;
     r=&(img->data[2])+row*img->stride;
     g=&(img->data[1])+row*img->stride;
     b=&(img->data[0])+row*img->stride;
+    alpha= &(img->data[3])+row*img->stride;
     for(col=0; col<img->w; col++) {
-      *(pixptr++) = *r;
-      *(pixptr++) = *g;
-      *(pixptr++) = *b;
+      if (*alpha == 255) {
+        *(pixptr++) = *r;
+        *(pixptr++) = *g;
+        *(pixptr++) = *b;
+      } else {
+        *(pixptr++) = 255;
+        *(pixptr++) = 255;
+        *(pixptr++) = 255;
+      }
       r+=4;
       g+=4;
       b+=4;
+      alpha+=4;
     }
     (void) jpeg_write_scanlines(&cinfo, &rowdata, 1);
   }


### PR DESCRIPTION
Hi,
after using the apache module mapCache, I had to do some changes to the code to fit best my needs.

I would like to share my considerations on some behavior: 

1) when you request a tile outside the extension of the tileset, you get the error.
with the configuration of the errors as empty_img it returns an empty image but the http response code was annoying, so I changed it to a response code of 200 and the browser will not log all the errors. 

2) configuring the mapcache with a jpeg output format, when I request a tile that is half-in and half-out the extension of the tileset, the half-out image had a black background, as I use maps with a white background, I changed it using the alpha channel
to determine which part to change to white. 

3) requesting images as png to maintain transparency, I had some trouble with the default image format which was JPEG,
this because in the code, the default format is get by dont know what and by default was jpeg.
I suggest to change it to take the default format specified in the mapcache xml configuration. 

I would like to know what you guys think of my changes.
