### PR TITLE
tileset with <grid maxzoom="x"> returns 404 / blank for GetMap request

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1300,7 +1300,7 @@ void mapcache_tileset_tile_validate(mapcache_context *ctx, mapcache_tile *tile);
  */
 void mapcache_tileset_get_level(mapcache_context *ctx, mapcache_tileset *tileset, double *resolution, int *level);
 
-void mapcache_grid_get_closest_level(mapcache_context *ctx, mapcache_grid *grid, double resolution, int *level);
+void mapcache_grid_get_closest_level(mapcache_context *ctx, mapcache_grid_link *grid, double resolution, int *level);
 void mapcache_tileset_tile_get(mapcache_context *ctx, mapcache_tile *tile);
 
 /**

--- a/lib/grid.c
+++ b/lib/grid.c
@@ -160,14 +160,14 @@ int mapcache_grid_get_level(mapcache_context *ctx, mapcache_grid *grid, double *
   return MAPCACHE_FAILURE;
 }
 
-void mapcache_grid_get_closest_level(mapcache_context *ctx, mapcache_grid *grid, double resolution, int *level)
+void mapcache_grid_get_closest_level(mapcache_context *ctx, mapcache_grid_link *grid_link, double resolution, int *level)
 {
-  double dst = fabs(grid->levels[0]->resolution - resolution);
+  double dst = fabs(grid_link->grid->levels[grid_link->minz]->resolution - resolution);
   int i;
   *level = 0;
 
-  for(i=1; i<grid->nlevels; i++) {
-    double curdst = fabs(grid->levels[i]->resolution - resolution);
+  for(i=grid_link->minz + 1; i<grid_link->maxz; i++) {
+    double curdst = fabs(grid_link->grid->levels[i]->resolution - resolution);
     if( curdst < dst) {
       dst = curdst;
       *level = i;

--- a/lib/tileset.c
+++ b/lib/tileset.c
@@ -185,7 +185,7 @@ void mapcache_tileset_get_map_tiles(mapcache_context *ctx, mapcache_tileset *til
   int x,y;
   int i=0;
   resolution = mapcache_grid_get_resolution(bbox, width, height);
-  mapcache_grid_get_closest_level(ctx,grid_link->grid,resolution,&level);
+  mapcache_grid_get_closest_level(ctx,grid_link,resolution,&level);
 
   mapcache_grid_get_xy(ctx,grid_link->grid,bbox->minx,bbox->miny,level,&bl_x,&bl_y);
   mapcache_grid_get_xy(ctx,grid_link->grid,bbox->maxx,bbox->maxy,level,&tr_x,&tr_y);


### PR DESCRIPTION
If a tileset is configured with <grid maxzoom="X"> mapcache will return a 404 error when a WMS GetMap is made when zoomed in beyond the maxzoom.  It should return a valid image, like a grid configured with only X <resolutions>
