### PR TITLE
MapCache sends invalid WMS GetCapabilities

### DIFF
--- a/lib/service_wms.c
+++ b/lib/service_wms.c
@@ -163,8 +163,6 @@ void _create_capabilities_wms(mapcache_context *ctx, mapcache_request_get_capabi
 
   vendorxml = ezxml_add_child(capxml,"VendorSpecificCapabilities",0);
   toplayer = ezxml_add_child(capxml,"Layer",0);
-  tmpxml = ezxml_add_child(toplayer,"Name",0);
-  ezxml_set_txt(tmpxml,"rootlayer");
   tmpxml = ezxml_add_child(toplayer,"Title",0);
   ezxml_set_txt(tmpxml,title);
 
@@ -201,15 +199,17 @@ void _create_capabilities_wms(mapcache_context *ctx, mapcache_request_get_capabi
 
     layerxml = ezxml_add_child(toplayer,"Layer",0);
     ezxml_set_attr(layerxml, "cascaded", "1");
-    ezxml_set_attr(layerxml, "queryable", (tileset->source && tileset->source->info_formats)?"1":"0"),
-                   ezxml_set_txt(ezxml_add_child(layerxml,"Name",0),tileset->name);
-
+    ezxml_set_attr(layerxml, "queryable", (tileset->source && tileset->source->info_formats)?"1":"0");
+    
+    ezxml_set_txt(ezxml_add_child(layerxml,"Name",0),tileset->name);
     tsxml = ezxml_add_child(vendorxml, "TileSet",0);
 
     /*optional layer title*/
     title = apr_table_get(tileset->metadata,"title");
     if(title) {
       ezxml_set_txt(ezxml_add_child(layerxml,"Title",0),title);
+    } else {
+      ezxml_set_txt(ezxml_add_child(layerxml,"Title",0),tileset->name);
     }
 
     /*optional layer abstract*/


### PR DESCRIPTION
MapCache WMS cannot be used with some WMS clients because of some issues in the WMS 1.1.1 GetCapabilities response.
- Content-Type is text/xml instead of application/vnd.ogc.wms_xml. However, I do not know if this is so bad for the clients. Behaviour is the same for me than in the the closed issue #35.
- Service is advertising a group layer "rootlayer, but it cannot be used for GetMaps. because MapCache does not recognize such layer.
- Layers have only `<Name>` but not `<Title>` which is compulsory

Below is an excerpt of the MapCache demo service from MS4W 3.1.0beta1 installation on Windows.

```
<Layer>
<Name>rootlayer</Name>
<Title>no title set, add some in metadata</Title>
<SRS>EPSG:900913</SRS>
<SRS>EPSG:4326</SRS>
<SRS>EPSG:3857</SRS>
  <Layer cascaded="1" queryable="0">
  <Name>test</Name>
  <LatLonBoundingBox minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>
  <BoundingBox SRS="EPSG:4326" minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>
  <SRS>EPSG:4326</SRS>
  <BoundingBox SRS="EPSG:900913" minx="-20037508.342789" miny="-20037508.342789" maxx="20037508.342789" maxy="20037508.342789"/>
  <SRS>EPSG:900913</SRS>
  <SRS>EPSG:3857</SRS>
  </Layer>
</Layer>
```
