### PR TITLE
TMS responses no longer include `Cache-Control` and `Expires` headers

### DIFF
--- a/lib/core.c
+++ b/lib/core.c
@@ -217,9 +217,9 @@ mapcache_http_response *mapcache_core_get_tile(mapcache_context *ctx, mapcache_r
   /* loop through tiles, and eventually merge them vertically together */
   for(i=0; i<req_tile->ntiles; i++) {
     mapcache_tile *tile = req_tile->tiles[i]; /* shortcut */
-    if(tile->mtime && tile->mtime < response->mtime)
+    if(tile->mtime && (tile->mtime < response->mtime || response->mtime == 0))
       response->mtime = tile->mtime;
-    if(tile->expires && tile->expires < expires) {
+    if(tile->expires && (tile->expires < expires || expires == 0)) {
       expires = tile->expires;
     }
     


### PR DESCRIPTION
Whilst I was updating node-mapcache to support the new mapcache CMake build system I noticed that a couple of tests in the node-mapcache test suite were failing which indicated that `Cache-Control` and `Expires` headers were no longer being generated for valid TMS requests.

Some regression testing showed that these headers were present prior to commit 4749ae24bc2e0d8def3922d7f9f07f9f29903e67 but not after it.  Note that those headers are still present for WMS requests.  I can't see why these headers have disappeared, hence this issue.
