### PR TITLE
Valid HTML and JS in demo service

### DIFF
--- a/lib/service_demo.c
+++ b/lib/service_demo.c
@@ -37,7 +37,8 @@
 /** @{ */
 
 static char *demo_head =
-  "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  "<!DOCTYPE html>\n"
+  "<html>\n"
   "  <head>\n"
   "    <title>mod-mapcache demo service</title>\n"
   "    <style type=\"text/css\">\n"


### PR DESCRIPTION
These three patches to lib/service_demo.c make the generated HTML and Javascript valid.

28c8713 & 3bf2803 are fixes to make the generated Javascript valid, and 293d029 sets the HTML5 DOCTYPE. Since users are recommended to copy/paste the demo service JS to get started with their own pages, I thought the upgrade to HTML5 from XHTML was appropriate. If you wish to stay with XHTML for the demo service, use this DOCTYPE instead:

``` html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
```
