### PR TITLE
Fix deletion of map tiles in seeder's delete mode

### DIFF
--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -569,7 +569,7 @@ void cmd_worker()
       tile->z = z;
       action = examine_tile(&cmd_ctx, tile);
 
-      if(action == MAPCACHE_CMD_SEED || action == MAPCACHE_CMD_TRANSFER) {
+      if(action == MAPCACHE_CMD_SEED || action == MAPCACHE_CMD_DELETE || action == MAPCACHE_CMD_TRANSFER) {
         //current x,y,z needs seeding, add it to the queue
         struct seed_cmd cmd;
         cmd.x = x;


### PR DESCRIPTION
The 'delete' mode in the seeder doesn't actually delete the the map tiles, unless,
as a workaround, drill-down iteration mode is explicitly set as a command parameter.

The tiles are marked for deletion, but the corresponding MAPCACHE_CMD_DELETE
is not passed to the workers.

This pull request fixes this issue.
