### PR TITLE
Use versioned SONAME for libmapcache.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ set(CMAKE_LINK_INTERFACE_LIBRARY "")
 file(GLOB mapcache_SOURCES lib/*.c )
 
 add_library(mapcache SHARED ${mapcache_SOURCES})
+set_target_properties(mapcache PROPERTIES
+  VERSION ${MAPCACHE_VERSION_STRING}
+  SOVERSION 1
+)
 
 #options suported by the cmake builder
 option(WITH_PIXMAN "Use pixman for SSE optimized image manipulations" ON)


### PR DESCRIPTION
While working on the Debian packages for MapCache 1.2.0 I notices that the SONAME was no longer versioned as it was in MapCache 1.0.0. This change sets the mapcache version and increases the SOVERSION to 1 because the mapcache_fetch_maps symbol was removed.
