### PR TITLE
Mirroring effect using OSGB projection

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -889,7 +889,7 @@ mapcache_image* mapcache_image_create_with_data(mapcache_context *ctx, int width
 void mapcache_image_copy_resampled_nearest(mapcache_context *ctx, mapcache_image *src, mapcache_image *dst,
     double off_x, double off_y, double scale_x, double scale_y);
 void mapcache_image_copy_resampled_bilinear(mapcache_context *ctx, mapcache_image *src, mapcache_image *dst,
-    double off_x, double off_y, double scale_x, double scale_y);
+    double off_x, double off_y, double scale_x, double scale_y, int reflect_edges);
 
 
 /**

--- a/lib/image.c
+++ b/lib/image.c
@@ -233,7 +233,7 @@ void mapcache_image_copy_resampled_nearest(mapcache_context *ctx, mapcache_image
 }
 
 void mapcache_image_copy_resampled_bilinear(mapcache_context *ctx, mapcache_image *src, mapcache_image *dst,
-    double off_x, double off_y, double scale_x, double scale_y)
+    double off_x, double off_y, double scale_x, double scale_y, int reflect_edges)
 {
 #ifdef USE_PIXMAN
   pixman_image_t *si = pixman_image_create_bits(PIXMAN_a8r8g8b8,src->w,src->h,
@@ -244,7 +244,9 @@ void mapcache_image_copy_resampled_bilinear(mapcache_context *ctx, mapcache_imag
   pixman_transform_init_translate(&transform,pixman_double_to_fixed(-off_x),pixman_double_to_fixed(-off_y));
   pixman_transform_scale(&transform,NULL,pixman_double_to_fixed(1.0/scale_x),pixman_double_to_fixed(1.0/scale_y));
   pixman_image_set_transform (si, &transform);
-  pixman_image_set_repeat (si, PIXMAN_REPEAT_REFLECT);
+  if(reflect_edges) {
+    pixman_image_set_repeat (si, PIXMAN_REPEAT_REFLECT);
+  }
   pixman_image_set_filter(si,PIXMAN_FILTER_BILINEAR, NULL, 0);
   pixman_image_composite (PIXMAN_OP_OVER, si, NULL, bi,
                           0, 0, 0, 0, 0, 0, dst->w,dst->h);

--- a/lib/tileset.c
+++ b/lib/tileset.c
@@ -340,7 +340,7 @@ mapcache_image* mapcache_tileset_assemble_map_tiles(mapcache_context *ctx, mapca
   } else {
     switch(mode) {
       case MAPCACHE_RESAMPLE_BILINEAR:
-        mapcache_image_copy_resampled_bilinear(ctx,srcimage,image,dstminx,dstminy,hf,vf);
+        mapcache_image_copy_resampled_bilinear(ctx,srcimage,image,dstminx,dstminy,hf,vf,0);
         break;
       default:
         mapcache_image_copy_resampled_nearest(ctx,srcimage,image,dstminx,dstminy,hf,vf);
@@ -691,7 +691,7 @@ void mapcache_tileset_assemble_out_of_zoom_tile(mapcache_context *ctx, mapcache_
      * ctx->log(ctx, MAPCACHE_DEBUG, "factor: %g. start: %g,%g (im size: %g)",scalefactor,dstminx,dstminy,scalefactor*256);
      */
     if(scalefactor <= tile->grid_link->grid->tile_sx/2) /*FIXME: might fail for non-square tiles, also check tile_sy */
-      mapcache_image_copy_resampled_bilinear(ctx,childtile->raw_image,tile->raw_image,dstminx,dstminy,scalefactor,scalefactor);
+      mapcache_image_copy_resampled_bilinear(ctx,childtile->raw_image,tile->raw_image,dstminx,dstminy,scalefactor,scalefactor,1);
     else {
       /* no use going through bilinear resampling if the requested scalefactor maps less than 4 pixels onto the
       * resulting tile, plus pixman has some rounding bugs in this case, see


### PR DESCRIPTION
Mirroring effect

When accessing a WMS layer in OSGB36 (British National Grid) projection, the area to the west of Scilly Islands (a group of islands off the westernmost tip of the Great Britain) appears mirrored, featuring a vertically flipped copy of Scilly Islands and South West England in the ocean. The attached screenshot serves as an illustration (true island on the right, mirrored copy on the left).

The MapCache configuration is as follows:

```
   <cache name="bgs_onshore2" type="bdb">
     <base>/bgs_onshore2</base>
   </cache>
   <source name="bgs_onshore2" type="wms">
      <getmap>
         <params>
            <FORMAT>image/png</FORMAT>
            <LAYERS>1</LAYERS>
            <TRANSPARENT>TRUE</TRANSPARENT>
         </params>
      </getmap>
      <http>         <url>http://maps.bgs.ac.uk/ArcGIS/services/BGS_Detailed_Geology/MapServer/WMSServer</url>
         <timeout>3600</timeout>
         <connection_timeout>3600</connection_timeout>
      </http>
   </source>
   <tileset name="bgs_onshore2">
      <metadata>
        <title>BGS Onshore Original</title>
      </metadata>
      <source>bgs_onshore2</source>
      <cache>bgs_onshore2</cache>
      <grid>BNG</grid>
      <format>PNG</format>
      <metatile>5 5</metatile>
      <metabuffer>10</metabuffer>
      <expires>86400</expires>
   </tileset>
```

The seeded tiles are accessed using the following URL:

http://localhost:3005/tiles?LAYERS=bgs_onshore2&TRANSPARENT=true&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image%2Fpng&SRS=EPSG%3A27700&BBOX=50030.292395313,-6259.7338946798,114893.56276466,30413.824507924&WIDTH=2167&HEIGHT=1225

This has been tested using node mapcache but that as the node bindings simply act as a http shim to the mapcache core it is expected to be replicable in the other mapcache interfaces.

![bgs_mirror](https://f.cloud.github.com/assets/5589208/1249477/128242e2-2ae1-11e3-94d7-c3264343f547.png)
