### PR TITLE
Problem with WMTS TileMatrix-values in some viewers

### DIFF
--- a/lib/service_wmts.c
+++ b/lib/service_wmts.c
@@ -414,7 +414,7 @@ void _create_capabilities_wmts(mapcache_context *ctx, mapcache_request_get_capab
         for(j=0; j<grid_link->grid->nlevels; j++) {
           ezxml_t matrixlimits = ezxml_add_child(limits,"TileMatrixLimits",0);
           ezxml_set_txt(ezxml_add_child(matrixlimits,"TileMatrix",0),
-                        apr_psprintf(ctx->pool,"%s:%d",grid_link->grid->name,j));
+                        apr_psprintf(ctx->pool,"%d",j));
           ezxml_set_txt(ezxml_add_child(matrixlimits,"MinTileRow",0),
                         apr_psprintf(ctx->pool,"%d",grid_link->grid_limits[j].minx));
           ezxml_set_txt(ezxml_add_child(matrixlimits,"MaxTileRow",0),


### PR DESCRIPTION
Some viewers (like the Geocortex Silverlight Viewer and arcgis.com) won't show wmts-tilesets because of a discrepancy in the capabilities provided by mapcache. These viewers expect a TileMatrix-value in a TileMatrixSetLink to be the same as/correspond with the ows:Identifier-value for the TileMatrix in the TileMatrixSet.
