### PR TITLE
watermark on request

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1257,6 +1257,11 @@ struct mapcache_tileset {
    */
   int auto_expire;
 
+  /**
+   * if the watermark should only be applied on request and not on storing the tile
+   */
+  int watermark_on_request;
+
   int read_only;
 
   /**

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -560,6 +560,7 @@ void parseTileset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
   mapcache_tileset *tileset = NULL;
   ezxml_t cur_node;
   char* value;
+  const char *attr = NULL;
   int havewgs84bbox=0;
   if(config->mode == MAPCACHE_MODE_NORMAL) {
     name = (char*)ezxml_attr(node,"name");
@@ -800,6 +801,10 @@ void parseTileset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     }
     mapcache_tileset_add_watermark(ctx,tileset,cur_node->txt);
     GC_CHECK_ERROR(ctx);
+
+    attr = ezxml_attr(cur_node,"onrequest");
+    if(attr && !strcasecmp(attr, "true"))
+      tileset->watermark_on_request = 1;
   }
 
 

--- a/lib/image.c
+++ b/lib/image.c
@@ -314,7 +314,8 @@ void mapcache_image_metatile_split(mapcache_context *ctx, mapcache_metatile *mt)
             break;
         }
         tileimg->data = &(metatile->data[sy*metatile->stride + 4 * sx]);
-        if(mt->map.tileset->watermark) {
+        if(mt->map.tileset->watermark && !mt->map.tileset->watermark_on_request) {
+          /* do not put watermark on cached tile if watermark_on_request is set */
           mapcache_image_merge(ctx,tileimg,mt->map.tileset->watermark);
           GC_CHECK_ERROR(ctx);
         }

--- a/lib/tileset.c
+++ b/lib/tileset.c
@@ -481,6 +481,7 @@ mapcache_tileset* mapcache_tileset_create(mapcache_context *ctx)
   tileset->metabuffer = 0;
   tileset->expires = 300; /*set a reasonable default to 5 mins */
   tileset->auto_expire = 0;
+  tileset->watermark_on_request = 0;
   tileset->read_only = 0;
   tileset->metadata = apr_table_make(ctx->pool,3);
   tileset->dimensions = NULL;
@@ -507,6 +508,7 @@ mapcache_tileset* mapcache_tileset_clone(mapcache_context *ctx, mapcache_tileset
   dst->cache = src->cache;
   dst->source = src->source;
   dst->watermark = src->watermark;
+  dst->watermark_on_request = src->watermark_on_request;
   dst->wgs84bbox = src->wgs84bbox;
   dst->format = src->format;
   return dst;

--- a/lib/tileset.c
+++ b/lib/tileset.c
@@ -840,9 +840,11 @@ void mapcache_tileset_tile_get(mapcache_context *ctx, mapcache_tile *tile)
       if(isLocked == MAPCACHE_FALSE) {
         ctx->set_error(ctx, 500, "tileset %s: unknown error (another thread/process failed to create the tile I was waiting for)",
                        tile->tileset->name);
+        return;
       } else {
         /* shouldn't really happen, as the error ought to have been caught beforehand */
         ctx->set_error(ctx, 500, "tileset %s: failed to re-get tile %d %d %d from cache after set", tile->tileset->name,tile->x,tile->y,tile->z);
+        return;
       }
     }
   }


### PR DESCRIPTION
The current watermark option always merges the watermarkfile on top of the tiles and then saves the watermarked tile in the cache.
I've added a option which still let you see a watermark on requested tiles, but which will not be saved watermarked to the cache.

To get this behaviour you have to add following to the configuration file:

``` xml
<tileset name="test">
    <watermark onrequest="true">/path/to/file</watermark>
</tileset>
```
