### PR TITLE
create world files

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -420,6 +420,7 @@ struct mapcache_cache_disk {
   char *filename_template;
   int symlink_blank;
   int creation_retry;
+  int create_world_file;
 
   /**
    * Set filename for a given tile
@@ -436,6 +437,7 @@ struct mapcache_cache_tiff {
   int count_x;
   int count_y;
   mapcache_image_format_jpeg *format;
+  int create_world_file;
 };
 #endif
 

--- a/lib/cache_disk.c
+++ b/lib/cache_disk.c
@@ -493,7 +493,8 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_tile *tile)
   apr_status_t ret;
   char errmsg[120];
   char *filename, *hackptr1, *hackptr2=NULL;
-  const int creation_retry = ((mapcache_cache_disk*)tile->tileset->cache)->creation_retry;
+  mapcache_cache_disk *dcache = (mapcache_cache_disk*)tile->tileset->cache;
+  const int creation_retry = dcache->creation_retry;
   int retry_count_create_file = 0;
 
 #ifdef DEBUG
@@ -508,7 +509,7 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_tile *tile)
   }
 #endif
 
-  ((mapcache_cache_disk*)tile->tileset->cache)->tile_key(ctx, tile, &filename);
+  dcache->tile_key(ctx, tile, &filename);
   GC_CHECK_ERROR(ctx);
 
   /* find the location of the last '/' in the string */
@@ -539,7 +540,7 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_tile *tile)
 
 
 #ifdef HAVE_SYMLINK
-  if(((mapcache_cache_disk*)tile->tileset->cache)->symlink_blank) {
+  if(dcache->symlink_blank) {
     if(!tile->raw_image) {
       tile->raw_image = mapcache_imageio_decode(ctx, tile->encoded_data);
       GC_CHECK_ERROR(ctx);
@@ -554,7 +555,7 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_tile *tile)
         }
         /* create the blank file */
         char *blankdirname = apr_psprintf(ctx->pool, "%s/%s/%s/blanks",
-                                          ((mapcache_cache_disk*)tile->tileset->cache)->base_directory,
+                                          dcache->base_directory,
                                           tile->tileset->name,
                                           tile->grid_link->grid->name);
         if(APR_SUCCESS != (ret = apr_dir_make_recursive(
@@ -602,7 +603,7 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_tile *tile)
       }
 
       /* create world file if desired */
-      if(((mapcache_cache_disk*)tile->tileset->cache)->create_world_file) {
+      if(dcache->create_world_file) {
         char osTFWText[1024];
         char *path;
         apr_file_t *f2;
@@ -734,7 +735,7 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_tile *tile)
   }
 
   /* create world file if desired */
-  if(((mapcache_cache_disk*)tile->tileset->cache)->create_world_file) {
+  if(dcache->create_world_file) {
     char osTFWText[1024];
     char *path;
     apr_file_t *f2;

--- a/lib/cache_tiff.c
+++ b/lib/cache_tiff.c
@@ -770,8 +770,8 @@ close_tiff:
                        dstminy);
 
     _mapcache_cache_tiff_tile_key(ctx, tile, &path);
-    if(strstr(*path,".tif"))
-      *path = mapcache_util_str_replace(ctx->pool,*path, ".tif", ".tfw");
+
+    path = mapcache_util_str_replace(ctx->pool, path, ".tif", ".tfw");
 
     if((ret = apr_file_open(&f2, path,
                             APR_FOPEN_CREATE|APR_FOPEN_WRITE,


### PR DESCRIPTION
When caching to disk or tiff it is useful to also create world files for the images.
So we are able to generate all tiles using mapcache_seed and then use the same raster data for a WMS service.

To use this feature following has to be added to the configuration file:

``` xml
<cache ...>
    <create_world_file/>
</cache>
```

We used the file extension ".wld" for the world files as suggested by MapServer ([see here](http://mapserver.org/de/input/raster.html#georeference-with-world-files)).
