### PR TITLE
JPEG output: enable optimized coding

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1590,6 +1590,15 @@ typedef enum {
   MAPCACHE_PHOTOMETRIC_YCBCR
 } mapcache_photometric;
 
+/**
+ * optimization settings (mostly) for jpeg
+ */
+typedef enum {
+  MAPCACHE_OPTIMIZE_NO,
+  MAPCACHE_OPTIMIZE_YES,
+  MAPCACHE_OPTIMIZE_ARITHMETIC
+} mapcache_optimization;
+
 /**\interface mapcache_image_format
  * \brief an image format
  * \sa mapcache_image_format_jpeg
@@ -1697,10 +1706,11 @@ struct mapcache_image_format_jpeg {
   mapcache_image_format format;
   int quality; /**< JPEG quality, 1-100 */
   mapcache_photometric photometric;
+  mapcache_optimization optimize;
 };
 
 mapcache_image_format* mapcache_imageio_create_jpeg_format(apr_pool_t *pool, char *name, int quality,
-    mapcache_photometric photometric);
+    mapcache_photometric photometric, mapcache_optimization optimize);
 
 /**
  * @param r

--- a/lib/configuration.c
+++ b/lib/configuration.c
@@ -170,7 +170,7 @@ mapcache_cfg* mapcache_configuration_create(apr_pool_t *pool)
           mapcache_imageio_create_png_q_format(pool,"PNG8",MAPCACHE_COMPRESSION_FAST,256),
           "PNG8");
   mapcache_configuration_add_image_format(cfg,
-          mapcache_imageio_create_jpeg_format(pool,"JPEG",90,MAPCACHE_PHOTOMETRIC_YCBCR),
+          mapcache_imageio_create_jpeg_format(pool,"JPEG",90,MAPCACHE_PHOTOMETRIC_YCBCR,MAPCACHE_OPTIMIZE_YES),
           "JPEG");
   mapcache_configuration_add_image_format(cfg,
           mapcache_imageio_create_mixed_format(pool,"mixed",

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -415,6 +415,7 @@ void parseFormat(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     }
   } else if(!strcmp(type,"JPEG")) {
     int quality = 95;
+    int optimize = TRUE;
     mapcache_photometric photometric = MAPCACHE_PHOTOMETRIC_YCBCR;
     if ((cur_node = ezxml_child(node,"quality")) != NULL) {
       char *endptr;
@@ -438,8 +439,21 @@ void parseFormat(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
         return;
       }
     }
+    if ((cur_node = ezxml_child(node,"optimize")) != NULL) {
+      if(cur_node->txt && !strcasecmp(cur_node->txt,"false"))
+        optimize = MAPCACHE_OPTIMIZE_NO;
+      else if(cur_node->txt && !strcasecmp(cur_node->txt,"true"))
+        optimize = MAPCACHE_OPTIMIZE_YES;
+      else if(cur_node->txt && !strcasecmp(cur_node->txt,"arithmetic"))
+        optimize = MAPCACHE_OPTIMIZE_ARITHMETIC;
+      else {
+        ctx->set_error(ctx,500,"failed to parse jpeg format %s optimize %s. expecting true, false or arithmetic",
+                       name,cur_node->txt);
+        return;
+      }
+    }
     format = mapcache_imageio_create_jpeg_format(ctx->pool,
-             name,quality,photometric);
+             name,quality,photometric,optimize);
   } else if(!strcasecmp(type,"MIXED")) {
     mapcache_image_format *transparent=NULL, *opaque=NULL;
     if ((cur_node = ezxml_child(node,"transparent")) != NULL) {

--- a/lib/imageio_jpeg.c
+++ b/lib/imageio_jpeg.c
@@ -188,6 +188,18 @@ mapcache_buffer* _mapcache_imageio_jpeg_encode(mapcache_context *ctx, mapcache_i
     default:
       jpeg_set_colorspace(&cinfo, JCS_YCbCr);
   }
+  switch(((mapcache_image_format_jpeg*)format)->optimize) {
+    case MAPCACHE_OPTIMIZE_NO:
+      cinfo.optimize_coding = FALSE;
+      break;
+    case MAPCACHE_OPTIMIZE_ARITHMETIC:
+      cinfo.optimize_coding = FALSE;
+      cinfo.arith_code = TRUE;
+      break;
+    case MAPCACHE_OPTIMIZE_YES:
+    default:
+      cinfo.optimize_coding = TRUE;
+  }
   jpeg_start_compress(&cinfo, TRUE);
 
   rowdata = (JSAMPLE*)malloc(img->w*cinfo.input_components*sizeof(JSAMPLE));
@@ -317,7 +329,7 @@ static mapcache_buffer* _mapcache_imageio_jpg_create_empty(mapcache_context *ctx
 }
 
 mapcache_image_format* mapcache_imageio_create_jpeg_format(apr_pool_t *pool, char *name, int quality,
-    mapcache_photometric photometric)
+    mapcache_photometric photometric, mapcache_optimization optimize)
 {
   mapcache_image_format_jpeg *format = apr_pcalloc(pool, sizeof(mapcache_image_format_jpeg));
   format->format.name = name;
@@ -327,6 +339,7 @@ mapcache_image_format* mapcache_imageio_create_jpeg_format(apr_pool_t *pool, cha
   format->format.create_empty_image = _mapcache_imageio_jpg_create_empty;
   format->format.write = _mapcache_imageio_jpeg_encode;
   format->quality = quality;
+  format->optimize = optimize;
   format->photometric = photometric;
   format->format.type = GC_JPEG;
   return (mapcache_image_format*)format;

--- a/mapcache.xml.sample
+++ b/mapcache.xml.sample
@@ -538,6 +538,7 @@
       <quality>75</quality>  
 
       <photometric>RGB</photometric>   <!-- RGB | YCBCR -->
+      <optimize>true</optimize>  <!-- true | false | arithmetic -->
    </format>
    <format name="PNG_BEST" type ="PNG">
       <compression>best</compression>


### PR DESCRIPTION
A port of Mapserver's issue mapserver/mapserver#5056 to MapCache. Enables optimized huffman tables for JPEG tile generation by default.
