### PR TITLE
Include <sys/stat.h> when not on windows.

### DIFF
--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -37,6 +37,7 @@
 #include <time.h>
 #ifndef _WIN32
 #include <unistd.h>
+#include <sys/stat.h>
 #define USE_FORK
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
Fixes build on OpenBSD, otherwise would fail with:
util/mapcache_seed.c:1255: error: 'S_IRUSR' undeclared (first use in this function)
util/mapcache_seed.c:1255: error: 'S_IWUSR' undeclared (first use in this function)