### PR TITLE
Sqlite cache backend does not create directory hierarchy for db files

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1748,6 +1748,7 @@ char* mapcache_util_get_tile_dimkey(mapcache_context *ctx, mapcache_tile *tile, 
 
 char* mapcache_util_get_tile_key(mapcache_context *ctx, mapcache_tile *tile, char *stemplate,
                                  char* sanitized_chars, char *sanitize_to);
+void mapcache_make_parent_dirs(mapcache_context *ctx, char *filename);
 
 /**\defgroup imageio Image IO */
 /** @{ */

--- a/lib/cache_sqlite.c
+++ b/lib/cache_sqlite.c
@@ -117,6 +117,8 @@ void mapcache_sqlite_connection_constructor(mapcache_context *ctx, void **conn_,
     flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX;
   } else {
     flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_CREATE;
+    mapcache_make_parent_dirs(ctx,sq_params->dbfile);
+    GC_CHECK_ERROR(ctx);
   }
   ret = sqlite3_open_v2(sq_params->dbfile, &conn->handle, flags, NULL);
   if (ret != SQLITE_OK) {

--- a/lib/cache_tiff.c
+++ b/lib/cache_tiff.c
@@ -512,10 +512,8 @@ static void _mapcache_cache_tiff_set(mapcache_context *ctx, mapcache_cache *pcac
   int rv;
   void *lock;
   int create;
-  char errmsg[120];
   mapcache_cache_tiff *cache;
   mapcache_image_format_jpeg *format;
-  char *hackptr1,*hackptr2;
   int tilew;
   int tileh;
   unsigned char *rgb;
@@ -541,27 +539,8 @@ static void _mapcache_cache_tiff_set(mapcache_context *ctx, mapcache_cache *pcac
   /*
    * create the directory where the tiff file will be stored
    */
-
-  /* find the location of the last '/' in the string */
-  hackptr2 = hackptr1 = filename;
-  while(*hackptr1) {
-    if(*hackptr1 == '/')
-      hackptr2 = hackptr1;
-    hackptr1++;
-  }
-  *hackptr2 = '\0';
-
-  if(APR_SUCCESS != (rv = apr_dir_make_recursive(filename,APR_OS_DEFAULT,ctx->pool))) {
-    /*
-     * apr_dir_make_recursive sometimes sends back this error, although it should not.
-     * ignore this one
-     */
-    if(!APR_STATUS_IS_EEXIST(rv)) {
-      ctx->set_error(ctx, 500, "failed to create directory %s: %s",filename, apr_strerror(rv,errmsg,120));
-      return;
-    }
-  }
-  *hackptr2 = '/';
+  mapcache_make_parent_dirs(ctx,filename);
+  GC_CHECK_ERROR(ctx);
 
   tilew = tile->grid_link->grid->tile_sx;
   tileh = tile->grid_link->grid->tile_sy;


### PR DESCRIPTION
Using multiple SQLite Database Files as cache backend, MapCache should create the directory hierarchy.
For instance, using the following configuration : 
<dbfile>/path/to/{tileset}/{z}/{x}-{y}.sqlite3</dbfile>

{z} folders are not created and the following error is reported : "sqlite backend failde to open db .... : unable to open database file"
