### PR TITLE
Fix various typos.

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -165,7 +165,7 @@ struct mapcache_context {
   void (*set_exception)(mapcache_context *ctx, char *key, char *message, ...);
 
   /**
-   * \brief query context to know if an error has occured
+   * \brief query context to know if an error has occurred
    * \memberof mapcache_context
    */
   int (*get_error)(mapcache_context * ctx);

--- a/lib/cache_tiff.c
+++ b/lib/cache_tiff.c
@@ -330,7 +330,7 @@ static int _mapcache_cache_tiff_get(mapcache_context *ctx, mapcache_cache *pcach
    * we currrently have no way of knowing if the opening failed because the tif
    * file does not exist (which is not an error condition, as it only signals
    * that the requested tile does not exist in the cache), or if an other error
-   * that should be signaled occured (access denied, not a tiff file, etc...)
+   * that should be signaled occurred (access denied, not a tiff file, etc...)
    *
    * we ignore this case here and hope that further parts of the code will be
    * able to detect what's happening more precisely

--- a/lib/core.c
+++ b/lib/core.c
@@ -620,7 +620,7 @@ mapcache_http_response* mapcache_core_respond_to_error(mapcache_context *ctx)
 
   msg = ctx->_errmsg;
   if(!msg) {
-    msg = apr_pstrdup(ctx->pool,"an unspecified error has occured");
+    msg = apr_pstrdup(ctx->pool,"an unspecified error has occurred");
   }
   ctx->log(ctx,MAPCACHE_ERROR,msg);
 

--- a/lib/service_demo.c
+++ b/lib/service_demo.c
@@ -281,7 +281,7 @@ static char *demo_head_gmaps =
   "      return null;\n"
   "    }\n"
   "\n"
-  "    // repeat accross x-axis\n"
+  "    // repeat across x-axis\n"
   "    if (x < 0 || x >= tileRange) {\n"
   "      x = (x % tileRange + tileRange) % tileRange;\n"
   "    }\n"

--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -1251,7 +1251,7 @@ int main(int argc, const char **argv)
     if(cache_override) {
       mapcache_cache *co = mapcache_configuration_get_cache(cfg, cache_override);
       if(!co) {
-        return usage(argv[0], "overrided cache\"%s\" to not found in configuration", cache_override);
+        return usage(argv[0], "overridden cache\"%s\" not found in configuration", cache_override);
       } else {
         tileset->_cache = co;
       }


### PR DESCRIPTION
The lintian QA tool reported these spelling errors for the recent rebuild of the MapCache 1.4.0 Debian package with GDAL 1.11.4 and 2.0.2:

 * occured -> occurred
 * accross -> across
 * overrided -> overridden