### PR TITLE
Insufficient validation of WMS source responses

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -156,12 +156,14 @@ void mapcache_http_do_request(mapcache_context *ctx, mapcache_http *req, mapcach
   if(req->post_body && req->post_len>0) {
     curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, req->post_body);
   }
+
+  if(!http_code)
+    curl_easy_setopt(curl_handle, CURLOPT_FAILONERROR, 1);
+
   /* get it! */
   ret = curl_easy_perform(curl_handle);
   if(http_code)
     curl_easy_getinfo (curl_handle, CURLINFO_RESPONSE_CODE, http_code);
-  else
-    curl_easy_setopt(curl_handle, CURLOPT_FAILONERROR, 1);
 
   if(ret != CURLE_OK) {
     ctx->set_error(ctx, 502, "curl failed to request url %s : %s", req->url, error_msg);

--- a/lib/image.c
+++ b/lib/image.c
@@ -291,6 +291,12 @@ void mapcache_image_metatile_split(mapcache_context *ctx, mapcache_metatile *mt)
       ctx->set_error(ctx, 500, "failed to load image data from metatile");
       return;
     }
+    if(metatile->w != mt->map.width ||
+       metatile->h != mt->map.height) {
+      ctx->set_error(ctx, 500, "image size does not correspond to metatile size");
+      return;
+    }
+
     for(i=0; i<mt->metasize_x; i++) {
       for(j=0; j<mt->metasize_y; j++) {
         tileimg = mapcache_image_create(ctx);


### PR DESCRIPTION
MapCache currently does not validate WMS GetMap responses sufficiently, leading to corrupted caches and/or segfaults in some cases:
- HTTP response code is not checked
- Returned image size is not checked against requested image size