### PR TITLE
Adds support for zoom level rules

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1076,13 +1076,13 @@ struct mapcache_rule {
    */
   int zoom_level;
   /**
-   * hidden tile color
+   * color of tiles when outside visible extent, ARGB
    */
   unsigned int hidden_color;
   /**
-   * readonly
+   * tile to return when outside visible extent
    */
-  int readonly;
+  mapcache_buffer *hidden_tile;
   /**
    * visible extents, array of mapcache_extent
    */
@@ -1354,13 +1354,6 @@ mapcache_rule* mapcache_ruleset_rule_get(apr_array_header_t *rules, int idx);
  * @param tile
  */
 int mapcache_ruleset_is_visible_tile(mapcache_rule* rule, mapcache_tile *tile);
-
-/**
- * \brief check if tile is readonly
- * @param rule
- * @param tile
- */
-int mapcache_ruleset_is_readonly_tile(mapcache_rule* rule, mapcache_tile *tile);
 
 
 /* in grid.c */

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1049,7 +1049,7 @@ struct mapcache_grid_link {
   int minz,maxz;
 
   /**
-   * rules (mapcache_rule) for each zoom level or NULL
+   * rules (mapcache_rule) for each zoom level
    * index in array = zoom level
    */
   apr_array_header_t *rules;

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1084,13 +1084,13 @@ struct mapcache_rule {
    */
   int readonly;
   /**
-   * visible extent
+   * visible extents, array of mapcache_extent
    */
-  mapcache_extent *visible_extent;
+  apr_array_header_t *visible_extents;
   /**
-   * visible limits
+   * visible limits, array of mapcache_extent_i
    */
-  mapcache_extent_i *visible_limits;
+  apr_array_header_t *visible_limits;
 };
 
 /**\class mapcache_ruleset

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1324,21 +1324,42 @@ mapcache_ruleset* mapcache_ruleset_create(apr_pool_t *pool);
  * \brief allocate and initialize a new rule
  * @param pool
  */
-mapcache_rule* mapcache_rule_create(apr_pool_t *pool);
+mapcache_rule* mapcache_ruleset_rule_create(apr_pool_t *pool);
 
 /**
  * \brief clone a rule
  * @param pool
  * @param rule
  */
-mapcache_rule* mapcache_rule_clone(apr_pool_t *pool, mapcache_rule *rule);
+mapcache_rule* mapcache_ruleset_rule_clone(apr_pool_t *pool, mapcache_rule *rule);
 
 /**
  * \brief get rule for zoom level, or NULL if none exist
  * @param ruleset
  * @param zoom_level
  */
-mapcache_rule* mapcache_rule_get(mapcache_ruleset *ruleset, int zoom_level);
+mapcache_rule* mapcache_ruleset_rule_find(apr_array_header_t *rules, int zoom_level);
+
+/**
+ * \brief get rule at index, or NULL if none exist
+ * @param rules
+ * @param idx
+ */
+mapcache_rule* mapcache_ruleset_rule_get(apr_array_header_t *rules, int idx);
+
+/**
+ * \brief check if tile is within visible extent
+ * @param rule
+ * @param tile
+ */
+int mapcache_ruleset_is_visible_tile(mapcache_rule* rule, mapcache_tile *tile);
+
+/**
+ * \brief check if tile is readonly
+ * @param rule
+ * @param tile
+ */
+int mapcache_ruleset_is_readonly_tile(mapcache_rule* rule, mapcache_tile *tile);
 
 
 /* in grid.c */

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -899,6 +899,7 @@ mapcache_ruleset *mapcache_configuration_get_ruleset(mapcache_cfg *config, const
 void mapcache_configuration_add_image_format(mapcache_cfg *config, mapcache_image_format *format, const char * key);
 void mapcache_configuration_add_source(mapcache_cfg *config, mapcache_source *source, const char * key);
 void mapcache_configuration_add_grid(mapcache_cfg *config, mapcache_grid *grid, const char * key);
+void mapcache_configuration_add_ruleset(mapcache_cfg *config, mapcache_ruleset *ruleset, const char * key);
 void mapcache_configuration_add_tileset(mapcache_cfg *config, mapcache_tileset *tileset, const char * key);
 void mapcache_configuration_add_cache(mapcache_cfg *config, mapcache_cache *cache, const char * key);
 

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -37,7 +37,8 @@ int mapcache_cache_tile_get(mapcache_context *ctx, mapcache_cache *cache, mapcac
 
   /* if tile is outside visible limits, return a blank tile */
   if (mapcache_ruleset_is_visible_tile(rule, tile) == MAPCACHE_FALSE) {
-    tile->encoded_data = rule->hidden_tile;
+    tile->encoded_data = mapcache_buffer_create(0, ctx->pool);
+    mapcache_buffer_append(tile->encoded_data, rule->hidden_tile->size, rule->hidden_tile->buf);
     return MAPCACHE_SUCCESS;
   }
 

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -28,67 +28,23 @@
 #include "mapcache.h"
 #include <apr_time.h>
 
-mapcache_rule* mapcache_cache_get_rule(mapcache_tile *tile) {
-  /* get rule for tile if available */
-  apr_array_header_t *rules = tile->grid_link->rules;
-  mapcache_rule *rule;
-
-  if(!rules) {
-    return NULL;
-  }
-
-  rule = APR_ARRAY_IDX(rules, tile->z, mapcache_rule*);
-  return rule;
-}
-
-int mapcache_cache_is_visible_tile(mapcache_tile *tile, mapcache_rule* rule) {
-  /* check if tile is within visible extent */
-  if(!rule) {
-    return MAPCACHE_TRUE;
-  }
-
-  if(!rule->visible_limits) {
-    return MAPCACHE_TRUE;
-  }
-
-  if(tile->x < rule->visible_limits->minx || tile->y < rule->visible_limits->miny || 
-     tile->x > rule->visible_limits->maxx || tile->y > rule->visible_limits->maxy) {
-    return MAPCACHE_FALSE;
-  }
-
-  return MAPCACHE_TRUE;
-}
-
-int mapcache_cache_is_readonly_tile(mapcache_tile *tile, mapcache_rule* rule) {
-  /* check if tile is tile readonly */
-  if(!rule) {
-    return MAPCACHE_FALSE;
-  }
-
-  if(rule->readonly) {
-    return MAPCACHE_TRUE;
-  }
-
-  return MAPCACHE_FALSE;
-}
-
 int mapcache_cache_tile_get(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile) {
   int i,rv;
-  mapcache_rule *rule = mapcache_cache_get_rule(tile);
+  mapcache_rule *rule = mapcache_ruleset_rule_get(tile->grid_link->rules, tile->z);
 #ifdef DEBUG
   ctx->log(ctx,MAPCACHE_DEBUG,"calling tile_get on cache (%s): (tileset=%s, grid=%s, z=%d, x=%d, y=%d",cache->name,tile->tileset->name,tile->grid_link->grid->name,tile->z,tile->x, tile->y);
 #endif
 
   /* if tile is outside visible extent, create a blank tile and return */
-  if (mapcache_cache_is_visible_tile(tile, rule) == MAPCACHE_FALSE) {
-     int tile_sx, tile_sy;
-     tile_sx = tile->grid_link->grid->tile_sx;
-     tile_sy = tile->grid_link->grid->tile_sy;
-     tile->encoded_data = tile->tileset->format->create_empty_image(ctx, tile->tileset->format, tile_sx, tile_sy, rule->hidden_color);
-     if(GC_HAS_ERROR(ctx)) {
-       return MAPCACHE_FAILURE;
-     }
-     return MAPCACHE_SUCCESS;
+  if (mapcache_ruleset_is_visible_tile(rule, tile) == MAPCACHE_FALSE) {
+    int tile_sx, tile_sy;
+    tile_sx = tile->grid_link->grid->tile_sx;
+    tile_sy = tile->grid_link->grid->tile_sy;
+    tile->encoded_data = tile->tileset->format->create_empty_image(ctx, tile->tileset->format, tile_sx, tile_sy, rule->hidden_color);
+    if(GC_HAS_ERROR(ctx)) {
+      return MAPCACHE_FAILURE;
+    }
+    return MAPCACHE_SUCCESS;
   }
 
   for(i=0;i<=cache->retry_count;i++) {
@@ -112,13 +68,13 @@ int mapcache_cache_tile_get(mapcache_context *ctx, mapcache_cache *cache, mapcac
 
 void mapcache_cache_tile_delete(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile) {
   int i;
-  mapcache_rule *rule = mapcache_cache_get_rule(tile);
+  mapcache_rule *rule = mapcache_ruleset_rule_get(tile->grid_link->rules, tile->z);
 #ifdef DEBUG
   ctx->log(ctx,MAPCACHE_DEBUG,"calling tile_delete on cache (%s): (tileset=%s, grid=%s, z=%d, x=%d, y=%d",cache->name,tile->tileset->name,tile->grid_link->grid->name,tile->z,tile->x, tile->y);
 #endif
 
-  /* if tile is readonly, return */
-  if (mapcache_cache_is_readonly_tile(tile, rule) == MAPCACHE_TRUE) {
+  /* if tile has a readonly rule, return */
+  if (mapcache_ruleset_is_readonly_tile(rule, tile) == MAPCACHE_TRUE) {
     return;
   }
 
@@ -144,14 +100,14 @@ void mapcache_cache_tile_delete(mapcache_context *ctx, mapcache_cache *cache, ma
 
 int mapcache_cache_tile_exists(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile) {
   int i,rv;
-  mapcache_rule *rule = mapcache_cache_get_rule(tile);
+  mapcache_rule *rule = mapcache_ruleset_rule_get(tile->grid_link->rules, tile->z);
 #ifdef DEBUG
   ctx->log(ctx,MAPCACHE_DEBUG,"calling tile_exists on cache (%s): (tileset=%s, grid=%s, z=%d, x=%d, y=%d",cache->name,tile->tileset->name,tile->grid_link->grid->name,tile->z,tile->x, tile->y);
 #endif
 
   /* if tile is outside visible limits return TRUE
      a blank tile will be returned on subsequent get call on cache */
-  if (mapcache_cache_is_visible_tile(tile, rule) == MAPCACHE_FALSE) {
+  if (mapcache_ruleset_is_visible_tile(rule, tile) == MAPCACHE_FALSE) {
     return MAPCACHE_TRUE;
   }
 
@@ -176,13 +132,13 @@ int mapcache_cache_tile_exists(mapcache_context *ctx, mapcache_cache *cache, map
 
 void mapcache_cache_tile_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile) {
   int i;
-  mapcache_rule *rule = mapcache_cache_get_rule(tile);
+  mapcache_rule *rule = mapcache_ruleset_rule_get(tile->grid_link->rules, tile->z);
 #ifdef DEBUG
   ctx->log(ctx,MAPCACHE_DEBUG,"calling tile_set on cache (%s): (tileset=%s, grid=%s, z=%d, x=%d, y=%d",cache->name,tile->tileset->name,tile->grid_link->grid->name,tile->z,tile->x, tile->y);
 #endif
 
-  /* if tile is readonly, return */
-  if (mapcache_cache_is_readonly_tile(tile, rule) == MAPCACHE_TRUE) {
+  /* if tile has a readonly rule, return */
+  if (mapcache_ruleset_is_readonly_tile(rule, tile) == MAPCACHE_TRUE) {
     return;
   }
 
@@ -213,10 +169,10 @@ void mapcache_cache_tile_multi_set(mapcache_context *ctx, mapcache_cache *cache,
       tiles[0].z,tiles[0].x, tiles[0].y);
 #endif
 
-  /* if any tile is readonly, return */
+  /* if any tile has a readonly rule, return */
   for(i = 0; i < ntiles; i++) {
-    mapcache_rule *rule = mapcache_cache_get_rule(tiles+i);
-    if (mapcache_cache_is_readonly_tile(tiles+i, rule) == MAPCACHE_TRUE) {
+    mapcache_rule *rule = mapcache_ruleset_rule_get((tiles+i)->grid_link->rules, (tiles+i)->z);
+    if (mapcache_ruleset_is_readonly_tile(rule, tiles+i) == MAPCACHE_TRUE) {
       return;
     }
   }

--- a/lib/configuration.c
+++ b/lib/configuration.c
@@ -271,6 +271,11 @@ void mapcache_configuration_add_grid(mapcache_cfg *config, mapcache_grid *grid, 
   apr_hash_set(config->grids, key, APR_HASH_KEY_STRING, (void*)grid);
 }
 
+void mapcache_configuration_add_ruleset(mapcache_cfg *config, mapcache_ruleset *ruleset, const char * key)
+{
+  apr_hash_set(config->rulesets, key, APR_HASH_KEY_STRING, (void*)ruleset);
+}
+
 void mapcache_configuration_add_tileset(mapcache_cfg *config, mapcache_tileset *tileset, const char * key)
 {
   tileset->config = config;

--- a/lib/configuration.c
+++ b/lib/configuration.c
@@ -127,6 +127,7 @@ mapcache_cfg* mapcache_configuration_create(apr_pool_t *pool)
   cfg->grids = apr_hash_make(pool);
   cfg->image_formats = apr_hash_make(pool);
   cfg->metadata = apr_table_make(pool,3);
+  cfg->rulesets = apr_hash_make(pool);
 
   mapcache_configuration_add_image_format(cfg,
           mapcache_imageio_create_png_format(pool,"PNG",MAPCACHE_COMPRESSION_FAST),
@@ -239,6 +240,11 @@ mapcache_cache *mapcache_configuration_get_cache(mapcache_cfg *config, const cha
 mapcache_grid *mapcache_configuration_get_grid(mapcache_cfg *config, const char *key)
 {
   return (mapcache_grid*)apr_hash_get(config->grids, (void*)key, APR_HASH_KEY_STRING);
+}
+
+mapcache_ruleset *mapcache_configuration_get_ruleset(mapcache_cfg *config, const char *key)
+{
+  return (mapcache_ruleset*)apr_hash_get(config->rulesets, (void*)key, APR_HASH_KEY_STRING);
 }
 
 mapcache_tileset *mapcache_configuration_get_tileset(mapcache_cfg *config, const char *key)

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -741,7 +741,7 @@ void parseTileset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     gridlink->grid_limits = (mapcache_extent_i*)apr_pcalloc(ctx->pool,grid->nlevels*sizeof(mapcache_extent_i));
     gridlink->outofzoom_strategy = MAPCACHE_OUTOFZOOM_NOTCONFIGURED;
     gridlink->intermediate_grids = apr_array_make(ctx->pool,1,sizeof(mapcache_grid_link*));
-    gridlink->rules = NULL;
+    gridlink->rules = apr_array_make(ctx->pool,0,sizeof(mapcache_rule*));
 
     ruleset_name = (char*)ezxml_attr(cur_node,"ruleset");
     if(ruleset_name) {
@@ -797,8 +797,6 @@ void parseTileset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     mapcache_grid_compute_limits(grid,extent,gridlink->grid_limits,tolerance);
 
     if(ruleset) {
-      gridlink->rules = apr_array_make(ctx->pool,grid->nlevels,sizeof(mapcache_rule*));
-
       for(i = 0; i < grid->nlevels; i++) {
         mapcache_rule *rule = mapcache_ruleset_rule_find(ruleset->rules, i);
 

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -244,6 +244,7 @@ void parseRuleset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
       APR_ARRAY_PUSH(ruleset->rules, mapcache_rule*) = clone_rule;
     }
   }
+  mapcache_configuration_add_ruleset(config,ruleset,ruleset->name);
 }
 
 void parseGrid(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
@@ -803,6 +804,7 @@ void parseTileset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
         if(rule) {
           mapcache_rule *rule_clone = mapcache_ruleset_rule_clone(ctx->pool, rule);
           if(rule->visible_extent) {
+            rule_clone->visible_limits = apr_pcalloc(ctx->pool, sizeof(mapcache_extent_i));
             mapcache_grid_compute_limits_at_level(grid,rule_clone->visible_extent,rule_clone->visible_limits,tolerance,i);
           }
           APR_ARRAY_PUSH(gridlink->rules, mapcache_rule*) = rule_clone;

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -1141,13 +1141,13 @@ void mapcache_configuration_parse_xml(mapcache_context *ctx, const char *filenam
     if(GC_HAS_ERROR(ctx)) goto cleanup;
   }
 
-  for(node = ezxml_child(doc,"tileset"); node; node = node->next) {
-    parseTileset(ctx, node, config);
+  for(node = ezxml_child(doc,"ruleset"); node; node = node->next) {
+    parseRuleset(ctx, node, config);
     if(GC_HAS_ERROR(ctx)) goto cleanup;
   }
 
-  for(node = ezxml_child(doc,"ruleset"); node; node = node->next) {
-    parseRuleset(ctx, node, config);
+  for(node = ezxml_child(doc,"tileset"); node; node = node->next) {
+    parseTileset(ctx, node, config);
     if(GC_HAS_ERROR(ctx)) goto cleanup;
   }
 

--- a/lib/ruleset.c
+++ b/lib/ruleset.c
@@ -48,8 +48,8 @@ mapcache_rule* mapcache_ruleset_rule_create(apr_pool_t *pool)
   rule->zoom_level = -1;
   rule->visible_extents = apr_array_make(pool,0,sizeof(mapcache_extent*));
   rule->visible_limits = apr_array_make(pool,0,sizeof(mapcache_extent_i*));
-  rule->hidden_color = 0xffffff; //default = white
-  rule->readonly = 0;
+  rule->hidden_color = 0x00ffffff; // default is white with full transparency
+  rule->hidden_tile = NULL;
   return rule;
 }
 
@@ -62,7 +62,7 @@ mapcache_rule* mapcache_ruleset_rule_clone(apr_pool_t *pool, mapcache_rule *rule
 
   clone->zoom_level = rule->zoom_level;
   clone->hidden_color = rule->hidden_color;
-  clone->readonly = rule->readonly;
+  clone->hidden_tile = rule->hidden_tile; //no need to copy, just point to same buffer/tile.
 
   if(rule->visible_extents) {
     int i;
@@ -108,7 +108,7 @@ mapcache_rule* mapcache_ruleset_rule_find(apr_array_header_t *rules, int zoom_le
 }
 
 /*
- * get rule at index, or NULL if none exist
+ * get rule at index, or NULL if index is out of bounds.
  */
 mapcache_rule* mapcache_ruleset_rule_get(apr_array_header_t *rules, int idx)
 {
@@ -123,7 +123,7 @@ mapcache_rule* mapcache_ruleset_rule_get(apr_array_header_t *rules, int idx)
 }
 
 /*
- * check if tile is within visible extents
+ * check if tile is within visible limits
  */
 int mapcache_ruleset_is_visible_tile(mapcache_rule* rule, mapcache_tile *tile) {
   int i;
@@ -139,17 +139,6 @@ int mapcache_ruleset_is_visible_tile(mapcache_rule* rule, mapcache_tile *tile) {
        tile->x <= extent->maxx && tile->y <= extent->maxy) {
       return MAPCACHE_TRUE;
     }
-  }
-
-  return MAPCACHE_FALSE;
-}
-
-/*
- * check if tile is readonly
- */
-int mapcache_ruleset_is_readonly_tile(mapcache_rule* rule, mapcache_tile *tile) {
-  if(rule && rule->readonly) {
-    return MAPCACHE_TRUE;
   }
 
   return MAPCACHE_FALSE;

--- a/lib/ruleset.c
+++ b/lib/ruleset.c
@@ -1,0 +1,93 @@
+/******************************************************************************
+ * $Id$
+ *
+ * Project:  MapServer
+ * Purpose:  MapCache ruleset support file
+ * Author:   Thomas Bonfort and the MapServer team.
+ *
+ ******************************************************************************
+ * Copyright (c) 1996-2011 Regents of the University of Minnesota.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies of this Software or works derived from this Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *****************************************************************************/
+
+#include "mapcache.h"
+
+/*
+ * allocate and initialize a new ruleset
+ */
+mapcache_ruleset* mapcache_ruleset_create(apr_pool_t *pool)
+{
+  mapcache_ruleset* ruleset = (mapcache_ruleset*)apr_pcalloc(pool, sizeof(mapcache_ruleset));
+  ruleset->rules = apr_array_make(pool,0,sizeof(mapcache_rule*));
+  return ruleset;
+}
+
+/*
+ * allocate and initialize a new rule
+ */
+mapcache_rule* mapcache_rule_create(apr_pool_t *pool)
+{
+  mapcache_rule* rule = (mapcache_rule*)apr_pcalloc(pool, sizeof(mapcache_rule));
+  rule->zoom_level = -1;
+  rule->visible_extent = NULL;
+  rule->visible_limits = NULL;
+  rule->hidden_color = 0xffffff; //default = white
+  rule->readonly = 0;
+  return rule;
+}
+
+/*
+ * clone a rule
+ */
+mapcache_rule* mapcache_rule_clone(apr_pool_t *pool, mapcache_rule *rule)
+{
+  mapcache_rule* clone = mapcache_rule_create(pool);
+
+  clone->zoom_level = rule->zoom_level;
+  clone->hidden_color = rule->hidden_color;
+  clone->readonly = rule->readonly;
+
+  if(rule->visible_extent) {
+    clone->visible_extent = (mapcache_extent*)apr_pcalloc(pool, sizeof(mapcache_extent));
+    *clone->visible_extent = *rule->visible_extent;
+  }
+
+  if(rule->visible_limits) {
+    clone->visible_limits = (mapcache_extent_i*)apr_pcalloc(pool, sizeof(mapcache_extent_i));
+    *clone->visible_limits = *rule->visible_limits;
+  }
+  
+  return clone;
+}
+
+/*
+ * get rule for zoom level, or NULL if none exist
+ */
+mapcache_rule* mapcache_rule_get(mapcache_ruleset *ruleset, int zoom_level)
+{
+  int i;
+  mapcache_rule* rule;
+  for(i = 0; i < ruleset->rules->nelts; i++) {
+    if ((rule = APR_ARRAY_IDX(ruleset->rules, i, mapcache_rule*))->zoom_level == zoom_level) {
+      return rule;
+    }
+  }
+  return NULL;
+}


### PR DESCRIPTION
Adds support for zoom level rules. This patch makes it possible to:
- Limit the visible extent on zoom levels in the cache. Tiles outside extent will be created on the fly using configured color (ARGB) and returned to the client in declared format, but not stored in the cache. Default tile color is white with full transparency, if supported by declared format.

In contrast to the already supported restricted_extent, visible extent will not change the extent that is announced to the client.

The use case for this is: Our tilecache has the extent of Europe, and is partly on demand seeded by incoming requests, but as you zoom in our data only covers Sweden. This feature will limit the potentially large number of useless tiles stored in the cache backend, and vill also protect our backend. I can also see this feature come in handy when you have islands of data inside a big extent.

Configuration example:

``` xml
<tileset name"tileset">
  ...
  <!-- reference the ruleset -->
  <grid ruleset="rules">grid</grid>
  ...
</tileset>

<!-- define ruleset -->
<ruleset name="rules">
  <!-- define rule for one or more zoom levels -->
  <rule zoom_level="4 5 6 7">
    <!-- set visible extents. hidden_color is the (hex) color (ARGB or RGB) of tiles outside extent.
         Default is a fully transparent tile -->
    <visibility hidden_color="ff000000">
      <!-- visible extents, can be more than one -->
      <extent>228355 6085026 953704 7686970</extent>
    </visibility>
  </rule>
  <!-- another rule -->
  <rule zoom_level="8 9 10">
    <visibility hidden_color="000000">
      <extent>335972 6099021 495792 6166722</extent>
      <extent>309336 6166722 644513 6273268</extent>
    </visibility>
  </rule>
</ruleset>
```
