### PR TITLE
In TileOutOfRange-exceptions the "locator"-value has no value

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1599,6 +1599,9 @@ int mapcache_grid_get_cell(mapcache_context *ctx, mapcache_grid *grid, mapcache_
  * @return
  */
 void mapcache_tileset_tile_validate(mapcache_context *ctx, mapcache_tile *tile);
+void mapcache_tileset_tile_validate_z(mapcache_context *ctx, mapcache_tile *tile);
+void mapcache_tileset_tile_validate_x(mapcache_context *ctx, mapcache_tile *tile);
+void mapcache_tileset_tile_validate_y(mapcache_context *ctx, mapcache_tile *tile);
 
 /**
  * compute level for a given resolution

--- a/lib/service_wmts.c
+++ b/lib/service_wmts.c
@@ -802,7 +802,7 @@ void _mapcache_service_wmts_parse_request(mapcache_context *ctx, mapcache_servic
 
   if(!matrixset) {
     ctx->set_error(ctx, 404, "received wmts request with no TILEMATRIXSET");
-    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","tilematrixset");
+    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","TileMatrixSet");
     return;
   } else {
     int i;
@@ -814,49 +814,49 @@ void _mapcache_service_wmts_parse_request(mapcache_context *ctx, mapcache_servic
     }
     if(!grid_link) {
       ctx->set_error(ctx, 404, "received wmts request with invalid TILEMATRIXSET %s",matrixset);
-      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","tilematrixset");
+      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","TileMatrixSet");
       return;
     }
   }
 
   if(!matrix) {
     ctx->set_error(ctx, 404, "received wmts request with no TILEMATRIX");
-    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","tilematrix");
+    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","TileMatrix");
     return;
   } else {
     char *endptr;
     level = (int)strtol(matrix,&endptr,10);
     if(*endptr != 0 || level < grid_link->minz || level >= grid_link->maxz) {
       ctx->set_error(ctx, 404, "received wmts request with invalid TILEMATRIX %s", matrix);
-      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","tilematrix");
+      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","TileMatrix");
       return;
     }
   }
 
   if(!tilerow) {
     ctx->set_error(ctx, 404, "received wmts request with no TILEROW");
-    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","tilerow");
+    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","TileRow");
     return;
   } else {
     char *endptr;
     row = (int)strtol(tilerow,&endptr,10);
     if(*endptr != 0 || row < 0) {
       ctx->set_error(ctx, 404, "received wmts request with invalid TILEROW %s",tilerow);
-      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","tilerow");
+      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","TileRow");
       return;
     }
   }
 
   if(!tilecol) {
     ctx->set_error(ctx, 404, "received wmts request with no TILECOL");
-    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","tilecol");
+    if(kvp) ctx->set_exception(ctx,"MissingParameterValue","TileCol");
     return;
   } else {
     char *endptr;
     col = (int)strtol(tilecol,&endptr,10);
     if(endptr == tilecol || col < 0) {
       ctx->set_error(ctx, 404, "received wmts request with invalid TILECOL %s",tilecol);
-      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","tilecol");
+      if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","TileCol");
       return;
     }
   }
@@ -960,9 +960,19 @@ void _mapcache_service_wmts_parse_request(mapcache_context *ctx, mapcache_servic
       req->tiles[i]->y = y;
       if(i==0) {
         /* no need to validate all the tiles as they all have the same x,y,z */
-        mapcache_tileset_tile_validate(ctx,req->tiles[0]);
+        mapcache_tileset_tile_validate_z(ctx,req->tiles[0]);
         if(GC_HAS_ERROR(ctx)) {
-          if(kvp) ctx->set_exception(ctx,"TileOutOfRange","");
+          if(kvp) ctx->set_exception(ctx,"InvalidParameterValue","TileMatrix");
+          return;
+        }
+        mapcache_tileset_tile_validate_x(ctx,req->tiles[0]);
+        if(GC_HAS_ERROR(ctx)) {
+          if(kvp) ctx->set_exception(ctx,"TileOutOfRange","TileCol");
+          return;
+        }
+        mapcache_tileset_tile_validate_y(ctx,req->tiles[0]);
+        if(GC_HAS_ERROR(ctx)) {
+          if(kvp) ctx->set_exception(ctx,"TileOutOfRange","TileRow");
           return;
         }
       }

--- a/lib/tileset.c
+++ b/lib/tileset.c
@@ -151,6 +151,30 @@ void mapcache_tileset_add_watermark(mapcache_context *ctx, mapcache_tileset *til
   tileset->watermark = mapcache_imageio_decode(ctx,watermarkdata);
 }
 
+void mapcache_tileset_tile_validate_z(mapcache_context *ctx, mapcache_tile *tile) {
+  if(tile->z < tile->grid_link->minz || tile->z >= tile->grid_link->maxz) {
+    ctx->set_error(ctx,404,"invalid tile z level");
+  }
+}
+
+void mapcache_tileset_tile_validate_x(mapcache_context *ctx, mapcache_tile *tile) {
+  mapcache_extent_i limits;
+  limits = tile->grid_link->grid_limits[tile->z];
+  if(tile->x<limits.minx || tile->x>=limits.maxx) {
+    ctx->set_error(ctx, 404, "tile x=%d not in [%d,%d[",
+                   tile->x,limits.minx,limits.maxx);
+  }
+}
+
+void mapcache_tileset_tile_validate_y(mapcache_context *ctx, mapcache_tile *tile) {
+  mapcache_extent_i limits;
+  limits = tile->grid_link->grid_limits[tile->z];
+  if(tile->y<limits.miny || tile->y>=limits.maxy) {
+    ctx->set_error(ctx, 404, "tile y=%d not in [%d,%d[",
+                   tile->y,limits.miny,limits.maxy);
+  }
+}
+
 void mapcache_tileset_tile_validate(mapcache_context *ctx, mapcache_tile *tile)
 {
   mapcache_extent_i limits;


### PR DESCRIPTION
According to the WMTS standard (I have looked in OGC 07-057r7), the "locator"-value of an exception with `exceptionCode=TileOutOfRange` should contain the name of the parameter which is out of range  (see Table 23 in [http://portal.opengeospatial.org/files/?artifact_id=35326](http://portal.opengeospatial.org/files/?artifact_id=35326)).

![image](https://cloud.githubusercontent.com/assets/2797067/18541597/6c16da64-7b26-11e6-83f6-57e812ae4cff.png)
_Screenshot of Table 23. The for grey exceptions are from the general OWS, the TileOutOfRange-exception is specific to WMTS_
