### PR TITLE
Add fallback source type to handle errors

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -917,6 +917,11 @@ void mapcache_source_query_info(mapcache_context *ctx, mapcache_source *source,
 mapcache_source* mapcache_source_gdal_create(mapcache_context *ctx);
 
 /**
+ * \memberof mapcache_source_fallback
+ */
+mapcache_source* mapcache_source_fallback_create(mapcache_context *ctx);
+
+/**
  * \memberof mapcache_source_wms
  */
 mapcache_source* mapcache_source_wms_create(mapcache_context *ctx);

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -265,7 +265,8 @@ typedef enum {
   MAPCACHE_SOURCE_WMS,
   MAPCACHE_SOURCE_MAPSERVER,
   MAPCACHE_SOURCE_DUMMY,
-  MAPCACHE_SOURCE_GDAL
+  MAPCACHE_SOURCE_GDAL,
+  MAPCACHE_SOURCE_FALLBACK
 } mapcache_source_type;
 
 /**\interface mapcache_source
@@ -285,11 +286,11 @@ struct mapcache_source {
    *
    * sets the mapcache_metatile::tile::data for the given tile
    */
-  void (*_render_map)(mapcache_context *ctx, mapcache_map *map);
+  void (*_render_map)(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map);
 
-  void (*query_info)(mapcache_context *ctx, mapcache_feature_info *fi);
+  void (*_query_info)(mapcache_context *ctx, mapcache_source *psource, mapcache_feature_info *fi);
 
-  void (*configuration_parse_xml)(mapcache_context *ctx, ezxml_t xml, mapcache_source * source);
+  void (*configuration_parse_xml)(mapcache_context *ctx, ezxml_t xml, mapcache_source * source, mapcache_cfg *config);
   void (*configuration_check)(mapcache_context *ctx, mapcache_cfg *cfg, mapcache_source * source);
 };
 
@@ -907,6 +908,8 @@ void mapcache_source_init(mapcache_context *ctx, mapcache_source *source);
  * \memberof mapcache_source
  */
 void mapcache_source_render_map(mapcache_context *ctx, mapcache_source *source, mapcache_map *map);
+void mapcache_source_query_info(mapcache_context *ctx, mapcache_source *source,
+    mapcache_feature_info *fi);
 
 /**
  * \memberof mapcache_source_gdal

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -342,6 +342,8 @@ void parseSource(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     source = mapcache_source_gdal_create(ctx);
   } else if(!strcmp(type,"dummy")) {
     source = mapcache_source_dummy_create(ctx);
+  } else if(!strcmp(type,"fallback")) {
+    source = mapcache_source_fallback_create(ctx);
   } else {
     ctx->set_error(ctx, 400, "unknown source type %s for source \"%s\"", type, name);
     return;

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -371,7 +371,7 @@ void parseSource(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     }
   }
 
-  source->configuration_parse_xml(ctx,node,source);
+  source->configuration_parse_xml(ctx,node,source, config);
   GC_CHECK_ERROR(ctx);
   source->configuration_check(ctx,config,source);
   GC_CHECK_ERROR(ctx);

--- a/lib/core.c
+++ b/lib/core.c
@@ -579,7 +579,7 @@ mapcache_http_response *mapcache_core_get_featureinfo(mapcache_context *ctx,
       ctx->set_error(ctx,404, "unsupported feature info format %s",fi->format);
       return NULL;
     }
-    tileset->source->query_info(ctx,fi);
+    mapcache_source_query_info(ctx, tileset->source, fi);
     if(GC_HAS_ERROR(ctx)) return NULL;
     response = mapcache_http_response_create(ctx->pool);
     response->data = fi->data;

--- a/lib/source.c
+++ b/lib/source.c
@@ -72,7 +72,7 @@ void mapcache_source_query_info(mapcache_context *ctx, mapcache_source *source, 
   int i;
 #ifdef DEBUG
   ctx->log(ctx, MAPCACHE_DEBUG, "calling query_info on source (%s): tileset=%s, grid=%s,",
-           source->name, fi->map.tileset->name, fi->map.grid_link->grid->name,);
+           source->name, fi->map.tileset->name, fi->map.grid_link->grid->name);
 #endif
   for(i=0;i<=source->retry_count;i++) {
     if(i) { /* not our first try */

--- a/lib/source_dummy.c
+++ b/lib/source_dummy.c
@@ -44,7 +44,7 @@ struct mapcache_source_dummy {
  * \private \memberof mapcache_source_dummy
  * \sa mapcache_source::render_map()
  */
-void _mapcache_source_dummy_render_map(mapcache_context *ctx, mapcache_map *map)
+void _mapcache_source_dummy_render_map(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
 {
   map->raw_image = mapcache_image_create(ctx);
   map->raw_image->w = map->width;
@@ -55,7 +55,7 @@ void _mapcache_source_dummy_render_map(mapcache_context *ctx, mapcache_map *map)
   apr_pool_cleanup_register(ctx->pool, map->raw_image->data,(void*)free, apr_pool_cleanup_null);
 }
 
-void _mapcache_source_dummy_query(mapcache_context *ctx, mapcache_feature_info *fi)
+void _mapcache_source_dummy_query(mapcache_context *ctx, mapcache_source *psource, mapcache_feature_info *fi)
 {
   ctx->set_error(ctx,500,"dummy source does not support queries");
 }
@@ -64,7 +64,7 @@ void _mapcache_source_dummy_query(mapcache_context *ctx, mapcache_feature_info *
  * \private \memberof mapcache_source_dummy
  * \sa mapcache_source::configuration_parse()
  */
-void _mapcache_source_dummy_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source *source)
+void _mapcache_source_dummy_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source *source, mapcache_cfg *config)
 {
 }
 
@@ -89,7 +89,7 @@ mapcache_source* mapcache_source_dummy_create(mapcache_context *ctx)
   source->source._render_map = _mapcache_source_dummy_render_map;
   source->source.configuration_check = _mapcache_source_dummy_configuration_check;
   source->source.configuration_parse_xml = _mapcache_source_dummy_configuration_parse_xml;
-  source->source.query_info = _mapcache_source_dummy_query;
+  source->source._query_info = _mapcache_source_dummy_query;
   return (mapcache_source*)source;
 }
 

--- a/lib/source_fallback.c
+++ b/lib/source_fallback.c
@@ -1,0 +1,165 @@
+/******************************************************************************
+ * $Id$
+ *
+ * Project:  MapServer
+ * Purpose:  MapCache tile caching support file: Mapserver Mapfile datasource
+ * Author:   Thomas Bonfort and the MapServer team.
+ *
+ ******************************************************************************
+ * Copyright (c) 1996-2011 Regents of the University of Minnesota.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies of this Software or works derived from this Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *****************************************************************************/
+
+
+#include "mapcache.h"
+#include "ezxml.h"
+#include <apr_tables.h>
+#include <apr_strings.h>
+
+typedef struct mapcache_source_fallback mapcache_source_fallback;
+struct mapcache_source_fallback {
+  mapcache_source source;
+  apr_array_header_t *sources;
+};
+
+/**
+ * \private \memberof mapcache_source_fallback
+ * \sa mapcache_source::render_map()
+ */
+void _mapcache_source_fallback_render_map(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
+{
+  mapcache_source_fallback *source = (mapcache_source_fallback*)psource;
+  mapcache_source *subsource;
+  int i;
+  subsource = APR_ARRAY_IDX(source->sources,0,mapcache_source*);
+  mapcache_source_render_map(ctx, subsource, map);
+  
+  if(GC_HAS_ERROR(ctx)) {
+    int first_error = ctx->get_error(ctx);
+    char *first_error_message = ctx->get_error_message(ctx);
+    ctx->log(ctx,MAPCACHE_INFO,
+        "failed render on primary source \"%s\" on tileset \"%s\". Falling back on secondary sources",
+        subsource->name,map->tileset->name);
+    ctx->clear_errors(ctx);
+    for(i=1; i<source->sources->nelts; i++) {
+      subsource = APR_ARRAY_IDX(source->sources,i,mapcache_source*);
+      mapcache_source_render_map(ctx, subsource, map);
+      if(GC_HAS_ERROR(ctx)) {
+        ctx->log(ctx,MAPCACHE_INFO,
+            "failed render on fallback source \"%s\" of tileset \"%s\". Continuing with other fallback sources if available",
+            subsource->name,map->tileset->name);
+        ctx->clear_errors(ctx);
+        continue;
+      } else {
+        return;
+      }
+    }
+    /* all backends failed, return primary error message */
+    ctx->set_error(ctx,first_error,first_error_message);
+    return;
+  }
+}
+
+void _mapcache_source_fallback_query(mapcache_context *ctx, mapcache_source *psource, mapcache_feature_info *fi)
+{
+  mapcache_source_fallback *source = (mapcache_source_fallback*)psource;
+  mapcache_source *subsource;
+  int i;
+  subsource = APR_ARRAY_IDX(source->sources,0,mapcache_source*);
+  mapcache_source_query_info(ctx, subsource, fi);
+  
+  if(GC_HAS_ERROR(ctx)) {
+    int first_error = ctx->get_error(ctx);
+    char *first_error_message = ctx->get_error_message(ctx);
+    ctx->log(ctx,MAPCACHE_INFO,
+        "failed query_info on primary source \"%s\" on tileset \"%s\". Falling back on secondary sources",
+        subsource->name,fi->map.tileset->name);
+    ctx->clear_errors(ctx);
+    for(i=1; i<source->sources->nelts; i++) {
+      subsource = APR_ARRAY_IDX(source->sources,i,mapcache_source*);
+      mapcache_source_query_info(ctx, subsource, fi);
+      if(GC_HAS_ERROR(ctx)) {
+        ctx->log(ctx,MAPCACHE_INFO,
+            "failed query_info on fallback source \"%s\" of tileset \"%s\". Continuing with other fallback sources if available",
+            subsource->name,fi->map.tileset->name);
+        ctx->clear_errors(ctx);
+        continue;
+      } else {
+        return;
+      }
+    }
+    /* all backends failed, return primary error message */
+    ctx->set_error(ctx,first_error,first_error_message);
+    return;
+  }
+  ctx->set_error(ctx,500,"fallback source does not support queries");
+}
+
+/**
+ * \private \memberof mapcache_source_fallback
+ * \sa mapcache_source::configuration_parse()
+ */
+void _mapcache_source_fallback_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source *psource, mapcache_cfg *config)
+{
+  ezxml_t cur_node;
+  mapcache_source_fallback *source = (mapcache_source_fallback*)psource;
+  source->sources = apr_array_make(ctx->pool,3,sizeof(mapcache_source*));
+  for(cur_node = ezxml_child(node,"source"); cur_node; cur_node = cur_node->next) {
+    mapcache_source *refsource = mapcache_configuration_get_source(config, cur_node->txt);
+    if(!refsource) {
+      ctx->set_error(ctx, 400, "fallback source \"%s\" references source \"%s\","
+                     " but it is not configured (hint:referenced sources must be declared before this fallback source in the xml file)", psource->name, cur_node->txt);
+      return;
+    }
+    APR_ARRAY_PUSH(source->sources,mapcache_source*) = refsource;
+  }
+  if(source->sources->nelts == 0) {
+    ctx->set_error(ctx,400,"fallback source \"%s\" does not reference any child sources", psource->name);
+  }
+}
+
+/**
+ * \private \memberof mapcache_source_fallback
+ * \sa mapcache_source::configuration_check()
+ */
+void _mapcache_source_fallback_configuration_check(mapcache_context *ctx, mapcache_cfg *cfg,
+    mapcache_source *source)
+{
+}
+
+mapcache_source* mapcache_source_fallback_create(mapcache_context *ctx)
+{
+  mapcache_source_fallback *source = apr_pcalloc(ctx->pool, sizeof(mapcache_source_fallback));
+  if(!source) {
+    ctx->set_error(ctx, 500, "failed to allocate fallback source");
+    return NULL;
+  }
+  mapcache_source_init(ctx, &(source->source));
+  source->source.type = MAPCACHE_SOURCE_FALLBACK;
+  source->source._render_map = _mapcache_source_fallback_render_map;
+  source->source.configuration_check = _mapcache_source_fallback_configuration_check;
+  source->source.configuration_parse_xml = _mapcache_source_fallback_configuration_parse_xml;
+  source->source._query_info = _mapcache_source_fallback_query;
+  return (mapcache_source*)source;
+}
+
+
+/* vim: ts=2 sts=2 et sw=2
+*/

--- a/lib/source_gdal.c
+++ b/lib/source_gdal.c
@@ -472,7 +472,7 @@ CreateWarpedVRT( GDALDatasetH hSrcDS,
  */
 void _mapcache_source_gdal_render_metatile(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
 {
-  mapcache_source_gdal *gdal = (mapcache_source_gdal*)map->tileset->source;
+  mapcache_source_gdal *gdal = (mapcache_source_gdal*)psource;
   gdal_connection *gdal_conn;
   GDALDatasetH  hDstDS;
   GDALDatasetH hTmpDS = NULL;

--- a/lib/source_gdal.c
+++ b/lib/source_gdal.c
@@ -470,7 +470,7 @@ CreateWarpedVRT( GDALDatasetH hSrcDS,
  * \private \memberof mapcache_source_gdal
  * \sa mapcache_source::render_metatile()
  */
-void _mapcache_source_gdal_render_metatile(mapcache_context *ctx, mapcache_map *map)
+void _mapcache_source_gdal_render_metatile(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
 {
   mapcache_source_gdal *gdal = (mapcache_source_gdal*)map->tileset->source;
   gdal_connection *gdal_conn;
@@ -604,7 +604,7 @@ void _mapcache_source_gdal_render_metatile(mapcache_context *ctx, mapcache_map *
  * \private \memberof mapcache_source_gdal
  * \sa mapcache_source::configuration_parse()
  */
-void _mapcache_source_gdal_configuration_parse(mapcache_context *ctx, ezxml_t node, mapcache_source *source)
+void _mapcache_source_gdal_configuration_parse(mapcache_context *ctx, ezxml_t node, mapcache_source *source, mapcache_cfg *config)
 {
   ezxml_t cur_node;
   mapcache_source_gdal *src = (mapcache_source_gdal*)source;

--- a/lib/source_mapserver.c
+++ b/lib/source_mapserver.c
@@ -190,7 +190,7 @@ void _mapcache_source_mapserver_render_map(mapcache_context *ctx, mapcache_map *
 
 }
 
-void _mapcache_source_mapserver_query(mapcache_context *ctx, mapcache_feature_info *fi)
+void _mapcache_source_mapserver_query(mapcache_context *ctx, mapcache_source *psource, mapcache_feature_info *fi)
 {
   ctx->set_error(ctx,500,"mapserver source does not support queries");
 }

--- a/lib/source_wms.c
+++ b/lib/source_wms.c
@@ -51,7 +51,7 @@ struct mapcache_source_wms {
  * \private \memberof mapcache_source_wms
  * \sa mapcache_source::render_map()
  */
-void _mapcache_source_wms_render_map(mapcache_context *ctx, mapcache_map *map)
+void _mapcache_source_wms_render_map(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
 {
   mapcache_source_wms *wms = (mapcache_source_wms*)map->tileset->source;
   mapcache_http *http;
@@ -99,7 +99,7 @@ void _mapcache_source_wms_render_map(mapcache_context *ctx, mapcache_map *map)
   }
 }
 
-void _mapcache_source_wms_query(mapcache_context *ctx, mapcache_feature_info *fi)
+void _mapcache_source_wms_query(mapcache_context *ctx, mapcache_source *source, mapcache_feature_info *fi)
 {
   mapcache_map *map = (mapcache_map*)fi;
   mapcache_http *http;
@@ -144,7 +144,7 @@ void _mapcache_source_wms_query(mapcache_context *ctx, mapcache_feature_info *fi
  * \private \memberof mapcache_source_wms
  * \sa mapcache_source::configuration_parse()
  */
-void _mapcache_source_wms_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source *source)
+void _mapcache_source_wms_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source *source, mapcache_cfg *config)
 {
   ezxml_t cur_node;
   mapcache_source_wms *src = (mapcache_source_wms*)source;
@@ -230,7 +230,7 @@ mapcache_source* mapcache_source_wms_create(mapcache_context *ctx)
   source->source._render_map = _mapcache_source_wms_render_map;
   source->source.configuration_check = _mapcache_source_wms_configuration_check;
   source->source.configuration_parse_xml = _mapcache_source_wms_configuration_parse_xml;
-  source->source.query_info = _mapcache_source_wms_query;
+  source->source._query_info = _mapcache_source_wms_query;
   source->wms_default_params = apr_table_make(ctx->pool,4);;
   source->getmap_params = apr_table_make(ctx->pool,4);
   source->getfeatureinfo_params = apr_table_make(ctx->pool,4);

--- a/lib/source_wms.c
+++ b/lib/source_wms.c
@@ -53,7 +53,7 @@ struct mapcache_source_wms {
  */
 void _mapcache_source_wms_render_map(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
 {
-  mapcache_source_wms *wms = (mapcache_source_wms*)map->tileset->source;
+  mapcache_source_wms *wms = (mapcache_source_wms*)psource;
   mapcache_http *http;
   apr_table_t *params = apr_table_clone(ctx->pool,wms->wms_default_params);
   apr_table_setn(params,"BBOX",apr_psprintf(ctx->pool,"%f,%f,%f,%f",
@@ -103,7 +103,7 @@ void _mapcache_source_wms_query(mapcache_context *ctx, mapcache_source *source, 
 {
   mapcache_map *map = (mapcache_map*)fi;
   mapcache_http *http;
-  mapcache_source_wms *wms = (mapcache_source_wms*)map->tileset->source;
+  mapcache_source_wms *wms = (mapcache_source_wms*)source;
 
   apr_table_t *params = apr_table_clone(ctx->pool,wms->wms_default_params);
   apr_table_overlap(params,wms->getmap_params,0);


### PR DESCRIPTION
In the same vein as fallback caches, this PR adds support for fallback sources. If the first configured source fails, mapcache will cycle the remaining configured sources until/if one succeeds. If all fail, the error message of the first failing source will be returned.

example usage/config:
```
<source name="wms1" type="wms">
 <!-- wms 1 config opts -->
</source>

<source name="wms2" type="wms">
 <!-- wms 2 config opts. Most probably the same as for wms except for the server hostname, unless you know what you are doing -->
</source>

<source name="fallbackwms" type="fallback">
 <source>wms1</source>
 <source>wms2</source>
</source>

<tileset name="foo">
 <source>fallbackwms</source>
 <!-- ... -->
</tileset>
```