### PR TITLE
Skip blank tiles for template disk cache

### DIFF
--- a/lib/cache_disk.c
+++ b/lib/cache_disk.c
@@ -49,7 +49,7 @@ struct mapcache_cache_disk {
   char *base_directory;
   char *filename_template;
   int symlink_blank;
-  int skip_blank;
+  int detect_blank;
   int creation_retry;
 
   /**
@@ -507,7 +507,7 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_cache *pcac
 
   cache->tile_key(ctx, cache, tile, &filename);
   GC_CHECK_ERROR(ctx);
-  if ( cache->skip_blank ) {
+  if ( cache->detect_blank ) {
     if(!tile->raw_image) {
       tile->raw_image = mapcache_imageio_decode(ctx, tile->encoded_data);
       GC_CHECK_ERROR(ctx);
@@ -721,8 +721,8 @@ static void _mapcache_cache_disk_configuration_parse_xml(mapcache_context *ctx, 
   if ((cur_node = ezxml_child(node,"creation_retry")) != NULL) {
     dcache->creation_retry = atoi(cur_node->txt);
   }
-  if ((cur_node = ezxml_child(node,"skip_blank")) != NULL) {
-    dcache->skip_blank=1;
+  if ((cur_node = ezxml_child(node,"detect_blank")) != NULL) {
+    dcache->detect_blank=1;
   }
 
 }
@@ -753,7 +753,7 @@ mapcache_cache* mapcache_cache_disk_create(mapcache_context *ctx)
     return NULL;
   }
   cache->symlink_blank = 0;
-  cache->skip_blank = 0;
+  cache->detect_blank = 0;
   cache->creation_retry = 0;
   cache->cache.metadata = apr_table_make(ctx->pool,3);
   cache->cache.type = MAPCACHE_CACHE_DISK;

--- a/lib/cache_disk.c
+++ b/lib/cache_disk.c
@@ -513,12 +513,14 @@ static void _mapcache_cache_disk_set(mapcache_context *ctx, mapcache_cache *pcac
       GC_CHECK_ERROR(ctx);
     }
     if(mapcache_image_blank_color(tile->raw_image) != MAPCACHE_FALSE) {
+      if(tile->raw_image->data[3] == 0) {
+        /* We have a blank (uniform) image who's first pixel is fully transparent, thus the whole image is transparent */
 #ifdef DEBUG
-      ctx->log(ctx, MAPCACHE_DEBUG, "skipped blank tile %s",filename);
+        ctx->log(ctx, MAPCACHE_DEBUG, "skipped blank tile %s",filename);
 #endif
-      // not sure if this is correct?
-      tile->nodata = 1;
-      return;
+        tile->nodata = 1;
+        return;
+      }
     }
   }
 

--- a/mapcache.xml
+++ b/mapcache.xml
@@ -6,6 +6,7 @@
    <cache name="disk" type="disk">
       <base>/tmp</base>
       <symlink_blank/>
+      <skip_blank/>
    </cache>
    <cache name="sqlite" type="sqlite3">
      <dbfile>/tmp/{tileset}-{z}-{grid}.db</dbfile>

--- a/mapcache.xml
+++ b/mapcache.xml
@@ -6,7 +6,7 @@
    <cache name="disk" type="disk">
       <base>/tmp</base>
       <symlink_blank/>
-      <skip_blank/>
+      <detect_blank/>
    </cache>
    <cache name="sqlite" type="sqlite3">
      <dbfile>/tmp/{tileset}-{z}-{grid}.db</dbfile>

--- a/mapcache.xml
+++ b/mapcache.xml
@@ -6,7 +6,6 @@
    <cache name="disk" type="disk">
       <base>/tmp</base>
       <symlink_blank/>
-      <detect_blank/>
    </cache>
    <cache name="sqlite" type="sqlite3">
      <dbfile>/tmp/{tileset}-{z}-{grid}.db</dbfile>

--- a/mapcache.xml.sample
+++ b/mapcache.xml.sample
@@ -357,11 +357,11 @@
            preserve disk space.
       -->
       <symlink_blank/>
-      <!-- skip_blank
+      <!-- detect_blank
           Similar to symlink_blank, except completely skip writing a file
-          if a blank tile is detected.
+          if a blank, fully transparent tile is detected.
       -->
-      <skip_blank/>
+      <detect_blank/>
    </cache>
 
    <cache name="tmpl" type="disk">
@@ -389,11 +389,11 @@
       -->
       <template>/tmp/template-test/{tileset}#{grid}#{dim}/{z}/{x}/{y}.{ext}</template>
 
-      <!-- skip_blank
+      <!-- detect_blank
           Similar to symlink_blank, except completely skip writing a file
-          if a blank tile is detected.
+          if a blank, fully transparent tile is detected.
       -->
-      <skip_blank/>
+      <detect_blank/>
    </cache>
 
    <!-- memcache cache

--- a/mapcache.xml.sample
+++ b/mapcache.xml.sample
@@ -360,6 +360,9 @@
       <!-- detect_blank
           Similar to symlink_blank, except completely skip writing a file
           if a blank, fully transparent tile is detected.
+          Note: This setting should only be used when using the seeder.  If used
+          on demand, mapcache will will query the WMS source on each subsequent 
+          tile request.
       -->
       <detect_blank/>
    </cache>
@@ -392,6 +395,9 @@
       <!-- detect_blank
           Similar to symlink_blank, except completely skip writing a file
           if a blank, fully transparent tile is detected.
+          Note: This setting should only be used when using the seeder.  If used
+          on demand, mapcache will will query the WMS source on each subsequent 
+          tile request.
       -->
       <detect_blank/>
    </cache>

--- a/mapcache.xml.sample
+++ b/mapcache.xml.sample
@@ -357,6 +357,11 @@
            preserve disk space.
       -->
       <symlink_blank/>
+      <!-- skip_blank
+          Similar to symlink_blank, except completely skip writing a file
+          if a blank tile is detected.
+      -->
+      <skip_blank/>
    </cache>
 
    <cache name="tmpl" type="disk">
@@ -383,6 +388,12 @@
 
       -->
       <template>/tmp/template-test/{tileset}#{grid}#{dim}/{z}/{x}/{y}.{ext}</template>
+
+      <!-- skip_blank
+          Similar to symlink_blank, except completely skip writing a file
+          if a blank tile is detected.
+      -->
+      <skip_blank/>
    </cache>
 
    <!-- memcache cache


### PR DESCRIPTION
Hello,

I needed a method to skip blank tiles in a disk cache template.  I have my own webserver methods to return a blank pixel when a file does not exist, so the symlink feature wasn't very helpful to me anyway.

In running a small test with 1280 tiles, my test machine instance finished the run in 43.9 seconds (29.2 tiles/sec) when skipping blank tiles.  222 non-blank tiles were created.  Without `skip_blank` in my `<cache>` directive, the extra 1058 blank tiles took 165.8 seconds, or 7.7 tiles/sec.  That's a 280% speed increase!

I also debated on naming the XML tag `detect_blank` to match up with the other cache methods, but I couldn't quite figure out if the memcache, sqlite, and RETS caches actually skipped the tile, or still created null content.  

I'd be happy to make any fixes or adjustments you'd like before merging this.

Thank you!

--Cal