### PR TITLE
Create MapCache Appveyor x64 Windows script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,6 +135,6 @@ test_script:
 deploy: off
 
 artifacts:
-  - path: %SDK_PREFIX%
+  - path: "%SDK_PREFIX%\\bin"
     name: mapcache
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -136,7 +136,7 @@ test_script:
   - set PATH_INFO="/"
   - set REQUEST_METHOD=GET
   - set QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image/png&SRS=EPSG:4326&BBOX=0,0,10,10&WIDTH=256&HEIGHT=256&LAYERS=test&TRANSPARENT=TRUE"
-  - mapcache.fcgi.exe > nul
+  - rem mapcache.fcgi.exe > nul
   - mapcache_seed.exe > nul
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,10 +22,9 @@ environment:
 shallow_clone: true
 
 install:
-    git clone https://github.com/Microsoft/vcpkg.git
-    git clone -n --depth=1 --branch=master https://github.com/Microsoft/vcpkg.git
-    ./bootstrap-vcpkg.bat
-    ./vcpkg.exe install apr-util:x64-windows 
+  - git clone https://github.com/Microsoft/vcpkg.git
+  - ./bootstrap-vcpkg.bat
+  - ./vcpkg.exe install apr-util:x64-windows
 
 #    choco install swig --version 1.3.40 --yes --limit-output
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,9 +69,7 @@ build_script:
         -DAPU_HAVE_ODBC=OFF 
         -DAPR_HAS_LDAP=OFF 
         -DAPR_BUILD_TESTAPR=OFF 
-        -DINSTALL_PDB=OFF 
-  - cd ..\..\apr-util-1.6.1
-  - echo %CD%
+        -DINSTALL_PDB=OFF ..\..\apr-util-1.6.1
   - nmake
   - nmake install
 
@@ -94,8 +92,7 @@ build_script:
         -DPCRE_SUPPORT_UTF=ON 
         -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON 
         -DPCRE_NEWLINE=CRLF 
-        -DINSTALL_MSVC_PDB=OFF 
-  - cd ..\..\%PCRE%
+        -DINSTALL_MSVC_PDB=OFF ..\..\%PCRE%
   - nmake
   - nmake install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,67 @@
+image: Visual Studio 2017
+
+platform:
+- x64
+- x86
+
+environment:
+  matrix:
+#
+# VS 2010
+#  - VS_VERSION: Visual Studio 10
+#
+# VS 2012
+#  - VS_VERSION: Visual Studio 11
+#
+# VS 2013
+#  - VS_VERSION: Visual Studio 12
+#
+# VS 2017
+  - VS_VERSION: Visual Studio 15 2017
+
+shallow_clone: true
+
+install:
+    git clone https://github.com/Microsoft/vcpkg.git
+    git clone -n --depth=1 --branch=master https://github.com/Microsoft/vcpkg.git
+    ./bootstrap-vcpkg.bat
+    ./vcpkg.exe install apr-util:x64-windows 
+
+#    choco install swig --version 1.3.40 --yes --limit-output
+
+build_script:
+  - echo build_script
+  - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
+  - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
+  - if "%platform%" == "x86" SET SDK=release-1800
+  - if "%platform%" == "x64" SET SDK=release-1800-x64
+  - echo "%VS_FULL%"
+  - set SDK_ZIP=%SDK%-dev.zip
+  - set SDK_URL=http://download.gisinternals.com/sdk/downloads/%SDK_ZIP%
+  - echo "%SDK_ZIP%"
+  - echo "%SDK_URL%"
+  - mkdir sdk
+  - cd sdk
+  - appveyor DownloadFile "%SDK_URL%"
+  - 7z x "%SDK_ZIP%" > nul
+  - cd %SDK%
+  - cd lib
+  - copy libpng.lib libpng.lib.lib
+  - cd ..
+  - cd ..
+  - cd ..
+  - set SDK_PREFIX=%CD%\sdk\%SDK%
+  - set SDK_INC=%CD%\sdk\%SDK%\include
+  - set SDK_LIB=%CD%\sdk\%SDK%\lib
+  - set SDK_BIN=%CD%\sdk\%SDK%\bin
+  # - set SWIG_EXECUTABLE=%CD%\sdk\SWIG-1.3.39\swig.exe
+  - set SWIG_EXECUTABLE=C:\ProgramData\chocolatey\bin\swig.exe
+  - set REGEX_DIR=%CD%\sdk\regex-0.12
+  - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:\python27\python.exe
+  - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:\python27-x64\python.exe
+  - mkdir build
+  - cd build
+  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DFREETYPE_INCLUDE_DIR_freetype2=%SDK_INC%\freetype -DFREETYPE_INCLUDE_DIR_ft2build=%SDK_INC%\freetype -DFREETYPE_LIBRARY=%SDK_LIB%\freetype2411.lib -DZLIB_INCLUDE_DIR=%SDK_INC% -DZLIB_LIBRARY=%SDK_LIB%\zlib.lib -DPNG_PNG_INCLUDE_DIR=%SDK_INC% -DPNG_LIBRARY=%SDK_LIB%\libpng.lib -DPNG_LIBRARIES=%SDK_LIB%\libpng.lib -DJPEG_INCLUDE_DIR=%SDK_INC% -DJPEG_LIBRARY=%SDK_LIB%\libjpeg.lib -DWITH_PROJ=1 -DPROJ_INCLUDE_DIR=%SDK_INC% -DPROJ_LIBRARY=%SDK_LIB%\proj_i.lib -DFRIBIDI_INCLUDE_DIR=%SDK_INC% -DFRIBIDI_LIBRARY=%SDK_LIB%\fribidi.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%\harfbuzz -DHARFBUZZ_LIBRARY=%SDK_LIB%\harfbuzz.lib -DICONV_INCLUDE_DIR=%SDK_INC% -DICONV_LIBRARY=%SDK_LIB%\iconv.lib -DICONV_DLL=%SDK_BIN%\iconv.dll -DCAIRO_INCLUDE_DIR=%SDK_INC% -DCAIRO_LIBRARY=%SDK_LIB%\cairo.lib -DFCGI_INCLUDE_DIR=%SDK_INC% -DFCGI_LIBRARY=%SDK_LIB%\libfcgi.lib -DGEOS_INCLUDE_DIR=%SDK_INC% -DGEOS_LIBRARY=%SDK_LIB%\geos_c.lib -DPOSTGRESQL_INCLUDE_DIR=%SDK_INC% -DPOSTGRESQL_LIBRARY=%SDK_LIB%\libpqdll.lib -DGDAL_INCLUDE_DIR=%SDK_INC% -DGDAL_LIBRARY=%SDK_LIB%\gdal_i.lib -DLIBXML2_INCLUDE_DIR=%SDK_INC%\libxml -DLIBXML2_LIBRARIES=%SDK_LIB%\libxml2.lib -DGIF_INCLUDE_DIR=%SDK_INC% -DGIF_LIBRARY=%SDK_LIB%\giflib.lib -DWITH_CURL=1 -DCURL_INCLUDE_DIR=%SDK_INC% -DCURL_LIBRARY=%SDK_LIB%\libcurl_imp.lib -DMS_EXTERNAL_LIBS=wsock32.lib -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1 -DSVG_INCLUDE_DIR=%SDK_INC% -DSVG_LIBRARY=%SDK_LIB%\libsvg.lib -DSVGCAIRO_INCLUDE_DIR=%SDK_INC% -DSVGCAIRO_LIBRARY=%SDK_LIB%\libsvg-cairo.lib -DWITH_SVGCAIRO=1 -DREGEX_DIR=%REGEX_DIR% -DWITH_POINT_Z_M=1 -DWITH_KML=1 -DWITH_THREAD_SAFETY=1 -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DWITH_PYTHON=1 -DPYTHON_EXECUTABLE=%PYTHON_EXECUTABLE% -DWITH_CSHARP=1
+  - cmake --build . --config Release
+
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,6 +112,7 @@ build_script:
         -DWITH_FCGI=ON 
         -DWITH_PCRE=ON 
         -DWITH_TIFF=OFF 
+        -DWITH_PIXMAN=OFF 
         -DCMAKE_PREFIX_PATH=%SDK_PREFIX% ..
   - cmake --build . --config Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ build_script:
   - echo build_script
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
-  - if "%platform%" == "x86" SET SDK=release-1800
-  - if "%platform%" == "x64" SET SDK=release-1800-x64
+  - if "%platform%" == "x86" SET SDK=release-1911
+  - if "%platform%" == "x64" SET SDK=release-1911-x64
   - echo "%VS_FULL%"
   - if "%platform%" == "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - if "%platform%" == "x86" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
@@ -112,7 +112,6 @@ build_script:
         -DWITH_FCGI=ON 
         -DWITH_PCRE=ON 
         -DWITH_TIFF=OFF 
-        -DWITH_PIXMAN=OFF 
         -DCMAKE_PREFIX_PATH=%SDK_PREFIX% ..
   - cmake --build . --config Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -136,8 +136,8 @@ test_script:
   - set PATH_INFO="/"
   - set REQUEST_METHOD=GET
   - set QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image/png&SRS=EPSG:4326&BBOX=0,0,10,10&WIDTH=256&HEIGHT=256&LAYERS=test&TRANSPARENT=TRUE"
-  - rem mapcache.fcgi.exe > nul
-  - mapcache_seed.exe > nul
+  - rem mapcache.fcgi.exe
+  - rem mapcache_seed.exe
 
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -127,7 +127,7 @@ build_script:
 
 after_build:
   - cd %SDK_PREFIX%\bin
-  - 7z a mapcache.zip libapr*.dll apr*.dll pcre.dll pcreposix.dll mapcache.dll 
+  - 7z a %APPVEYOR_BUILD_FOLDER%\mapcache.zip libapr*.dll apr*.dll pcre.dll pcreposix.dll mapcache.dll 
         mapcache.fcgi.exe mapcache_seed.exe %APPVEYOR_BUILD_FOLDER%\mapcache.xml
 
 test_script:
@@ -142,6 +142,6 @@ test_script:
 deploy: off
 
 artifacts:
-  - path: '%APPVEYOR_BUILD_FOLDER%\mapcache.zip'
+  - path: mapcache.zip
     name: mapcache
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - cd %SDK%
   - cd lib
   - copy libpng.lib libpng.lib.lib
-  - cd {APPVEYOR_BUILD_FOLDER}
+  - cd %APPVEYOR_BUILD_FOLDER%
   - set SDK_PREFIX=%CD%\sdk\%SDK%
   - set SDK_INC=%CD%\sdk\%SDK%\include
   - set SDK_LIB=%CD%\sdk\%SDK%\lib
@@ -55,7 +55,7 @@ build_script:
   - nmake
   - nmake install
 
-  - cd {APPVEYOR_BUILD_FOLDER}
+  - cd %APPVEYOR_BUILD_FOLDER%
 
   - if not exist apr-util-1.6.1-win32-src.zip appveyor DownloadFile http://apache.mindstudios.com/apr/apr-util-1.6.1-win32-src.zip
   - 7z x apr-util-1.6.1-win32-src.zip
@@ -74,7 +74,7 @@ build_script:
   - nmake
   - nmake install
 
-  - cd {APPVEYOR_BUILD_FOLDER}
+  - cd %APPVEYOR_BUILD_FOLDER%
 
   - set PCRE_VERSION=8.38
   - set PCRE=pcre-%PCRE_VERSION%
@@ -105,7 +105,7 @@ build_script:
   - copy %SDK_PREFIX%\lib\libaprutil-1.lib %SDK_PREFIX%\lib\aprutil-1.lib /Y > nul
   - xcopy %REGEX_DIR%\*.h %SDK_PREFIX%\include\ /O /X /E /H /K /Y > nul
 
-  - cd {APPVEYOR_BUILD_FOLDER}
+  - cd %APPVEYOR_BUILD_FOLDER%
 
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,31 +2,13 @@ image: Visual Studio 2017
 
 platform:
 - x64
-- x86
 
 environment:
   matrix:
-#
-# VS 2010
-#  - VS_VERSION: Visual Studio 10
-#
-# VS 2012
-#  - VS_VERSION: Visual Studio 11
-#
-# VS 2013
-#  - VS_VERSION: Visual Studio 12
-#
 # VS 2017
   - VS_VERSION: Visual Studio 15 2017
 
 shallow_clone: true
-
-install:
-  - git clone https://github.com/Microsoft/vcpkg.git
-  - ./bootstrap-vcpkg.bat
-  - ./vcpkg.exe install apr-util:x64-windows
-
-#    choco install swig --version 1.3.40 --yes --limit-output
 
 build_script:
   - echo build_script
@@ -35,6 +17,8 @@ build_script:
   - if "%platform%" == "x86" SET SDK=release-1800
   - if "%platform%" == "x64" SET SDK=release-1800-x64
   - echo "%VS_FULL%"
+  - if "%platform%" == "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
+  - if "%platform%" == "x86" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars32.bat"
   - set SDK_ZIP=%SDK%-dev.zip
   - set SDK_URL=http://download.gisinternals.com/sdk/downloads/%SDK_ZIP%
   - echo "%SDK_ZIP%"
@@ -46,21 +30,111 @@ build_script:
   - cd %SDK%
   - cd lib
   - copy libpng.lib libpng.lib.lib
-  - cd ..
-  - cd ..
-  - cd ..
+  - cd {APPVEYOR_BUILD_FOLDER}
   - set SDK_PREFIX=%CD%\sdk\%SDK%
   - set SDK_INC=%CD%\sdk\%SDK%\include
   - set SDK_LIB=%CD%\sdk\%SDK%\lib
   - set SDK_BIN=%CD%\sdk\%SDK%\bin
-  # - set SWIG_EXECUTABLE=%CD%\sdk\SWIG-1.3.39\swig.exe
-  - set SWIG_EXECUTABLE=C:\ProgramData\chocolatey\bin\swig.exe
   - set REGEX_DIR=%CD%\sdk\regex-0.12
-  - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:\python27\python.exe
-  - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:\python27-x64\python.exe
+
+  - if not exist apr-1.6.3-win32-src.zip appveyor DownloadFile http://apache.mindstudios.com/apr/apr-1.6.3-win32-src.zip
+  - 7z x apr-1.6.3-win32-src.zip
+  - mkdir build-cmake
+  - cd build-cmake
+  - mkdir apr
+  - cd apr
+  - cmake -G "NMake Makefiles" ^
+        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% ^
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+        -DMIN_WINDOWS_VER=0x0600 ^
+        -DAPR_HAVE_IPV6=ON ^
+        -DAPR_INSTALL_PRIVATE_H=ON ^
+        -DAPR_BUILD_TESTAPR=OFF ^
+        -DAPU_HAVE_ODBC=OFF ^
+        -DINSTALL_PDB=OFF ..\..\apr-1.6.3
+  - nmake
+  - nmake install
+
+  - cd {APPVEYOR_BUILD_FOLDER}
+
+  - if not exist apr-util-1.6.1-win32-src.zip appveyor DownloadFile http://apache.mindstudios.com/apr/apr-util-1.6.1-win32-src.zip
+  - 7z x apr-util-1.6.1-win32-src.zip
+  - mkdir build-cmake\apr-util
+  - cd build-cmake\apr-util
+  - cmake -G "NMake Makefiles" ^
+        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% ^
+        -DOPENSSL_ROOT_DIR=%SDK_PREFIX% ^
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+        -DAPU_HAVE_CRYPTO=ON ^
+        -DAPU_HAVE_ODBC=OFF ^
+        -DAPR_HAS_LDAP=OFF ^
+        -DAPR_BUILD_TESTAPR=OFF ^
+        -DINSTALL_PDB=OFF ^
+  - ..\..\apr-util-1.6.1
+  - nmake
+  - nmake install
+
+  - cd {APPVEYOR_BUILD_FOLDER}
+
+  - set PCRE_VERSION=8.38
+  - set PCRE=pcre-%PCRE_VERSION%
+  - if not exist %PCRE%.zip appveyor DownloadFile "http://zoo-project.org/dl/%PCRE%.zip"
+  - 7z x %PCRE%.zip > nul
+  - mkdir build-cmake\pcre
+  - cd build-cmake\pcre
+  - cmake -G "NMake Makefiles" ^
+        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% ^
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+        -DBUILD_SHARED_LIBS=ON ^
+        -DPCRE_BUILD_TESTS=OFF ^
+        -DPCRE_BUILD_PCRECPP=OFF ^
+        -DPCRE_BUILD_PCREGREP=OFF ^
+        -DPCRE_SUPPORT_PCREGREP_JIT=OFF ^
+        -DPCRE_SUPPORT_UTF=ON ^
+        -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON ^
+        -DPCRE_NEWLINE=CRLF ^
+        -DINSTALL_MSVC_PDB=OFF ^
+  - ..\..\%PCRE%
+  - nmake
+  - nmake install
+
+  - copy %SDK_PREFIX%\lib\libfcgi.lib %SDK_PREFIX%\lib\fcgi.lib /Y > nul
+  - copy %SDK_PREFIX%\lib\apr-1.lib %SDK_PREFIX%\lib\apr-1-1.lib /Y > nul
+  - copy %SDK_PREFIX%\lib\libapr-1.lib %SDK_PREFIX%\lib\apr-1.lib /Y > nul
+  - copy %SDK_PREFIX%\lib\aprutil-1.lib %SDK_PREFIX%\lib\aprutil-1-1.lib /Y > nul
+  - copy %SDK_PREFIX%\lib\libaprutil-1.lib %SDK_PREFIX%\lib\aprutil-1.lib /Y > nul
+  - xcopy %REGEX_DIR%\*.h %SDK_PREFIX%\include\ /O /X /E /H /K /Y > nul
+
+  - cd {APPVEYOR_BUILD_FOLDER}
+
   - mkdir build
   - cd build
-  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DFREETYPE_INCLUDE_DIR_freetype2=%SDK_INC%\freetype -DFREETYPE_INCLUDE_DIR_ft2build=%SDK_INC%\freetype -DFREETYPE_LIBRARY=%SDK_LIB%\freetype2411.lib -DZLIB_INCLUDE_DIR=%SDK_INC% -DZLIB_LIBRARY=%SDK_LIB%\zlib.lib -DPNG_PNG_INCLUDE_DIR=%SDK_INC% -DPNG_LIBRARY=%SDK_LIB%\libpng.lib -DPNG_LIBRARIES=%SDK_LIB%\libpng.lib -DJPEG_INCLUDE_DIR=%SDK_INC% -DJPEG_LIBRARY=%SDK_LIB%\libjpeg.lib -DWITH_PROJ=1 -DPROJ_INCLUDE_DIR=%SDK_INC% -DPROJ_LIBRARY=%SDK_LIB%\proj_i.lib -DFRIBIDI_INCLUDE_DIR=%SDK_INC% -DFRIBIDI_LIBRARY=%SDK_LIB%\fribidi.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%\harfbuzz -DHARFBUZZ_LIBRARY=%SDK_LIB%\harfbuzz.lib -DICONV_INCLUDE_DIR=%SDK_INC% -DICONV_LIBRARY=%SDK_LIB%\iconv.lib -DICONV_DLL=%SDK_BIN%\iconv.dll -DCAIRO_INCLUDE_DIR=%SDK_INC% -DCAIRO_LIBRARY=%SDK_LIB%\cairo.lib -DFCGI_INCLUDE_DIR=%SDK_INC% -DFCGI_LIBRARY=%SDK_LIB%\libfcgi.lib -DGEOS_INCLUDE_DIR=%SDK_INC% -DGEOS_LIBRARY=%SDK_LIB%\geos_c.lib -DPOSTGRESQL_INCLUDE_DIR=%SDK_INC% -DPOSTGRESQL_LIBRARY=%SDK_LIB%\libpqdll.lib -DGDAL_INCLUDE_DIR=%SDK_INC% -DGDAL_LIBRARY=%SDK_LIB%\gdal_i.lib -DLIBXML2_INCLUDE_DIR=%SDK_INC%\libxml -DLIBXML2_LIBRARIES=%SDK_LIB%\libxml2.lib -DGIF_INCLUDE_DIR=%SDK_INC% -DGIF_LIBRARY=%SDK_LIB%\giflib.lib -DWITH_CURL=1 -DCURL_INCLUDE_DIR=%SDK_INC% -DCURL_LIBRARY=%SDK_LIB%\libcurl_imp.lib -DMS_EXTERNAL_LIBS=wsock32.lib -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1 -DSVG_INCLUDE_DIR=%SDK_INC% -DSVG_LIBRARY=%SDK_LIB%\libsvg.lib -DSVGCAIRO_INCLUDE_DIR=%SDK_INC% -DSVGCAIRO_LIBRARY=%SDK_LIB%\libsvg-cairo.lib -DWITH_SVGCAIRO=1 -DREGEX_DIR=%REGEX_DIR% -DWITH_POINT_Z_M=1 -DWITH_KML=1 -DWITH_THREAD_SAFETY=1 -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DWITH_PYTHON=1 -DPYTHON_EXECUTABLE=%PYTHON_EXECUTABLE% -DWITH_CSHARP=1
+  - cmake -G "%VS_FULL%" ^
+        -DWITH_APACHE=OFF ^
+        -DWITH_FCGI=ON ^
+        -DWITH_PCRE=ON ^
+        -DWITH_TIFF=OFF ^
+        -DCMAKE_PREFIX_PATH=%SDK_PREFIX% ..
   - cmake --build . --config Release
 
+  - copy %SDK_PREFIX%\lib\apr-1-1.lib %SDK_PREFIX%\lib\apr-1.lib /Y > nul
+  - copy %SDK_PREFIX%\lib\aprutil-1-1.lib %SDK_PREFIX%\lib\aprutil-1.lib /Y > nul
+  - copy %SDK_PREFIX%\bin\libapr-1.dll %SDK_PREFIX%\bin\apr-1.dll /Y > nul
+  - copy %SDK_PREFIX%\bin\libaprutil-1.dll %SDK_PREFIX%\bin\aprutil-1.dll /Y > nul
+  - copy %SDK_PREFIX%\bin\libfcgi.dll %SDK_PREFIX%\bin\fcgi.dll /Y > nul
+  - copy Release\*dll %SDK_PREFIX%\bin\ /Y > nul
+  - copy Release\*lib %SDK_PREFIX%\lib\ /Y > nul
+  - copy cgi\Release\*exe %SDK_PREFIX%\bin\ /Y > nul
+  - copy util\Release\*exe %SDK_PREFIX%\bin\ /Y > nul
+
+test_script:
+  - cd %SDK_PREFIX%\bin
+  - mapcache.fcgi.exe
+  - mapcache_seed.exe
+
 deploy: off
+
+artifacts:
+  - path: %SDK_PREFIX%
+    name: mapcache
+    type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -125,14 +125,23 @@ build_script:
   - copy cgi\Release\*exe %SDK_PREFIX%\bin\ /Y > nul
   - copy util\Release\*exe %SDK_PREFIX%\bin\ /Y > nul
 
+after_build:
+  - cd %SDK_PREFIX%\bin
+  - 7z a mapcache.zip libapr*.dll apr*.dll pcre.dll pcreposix.dll mapcache.dll 
+        mapcache.fcgi.exe mapcache_seed.exe %APPVEYOR_BUILD_FOLDER%\mapcache.xml
+
 test_script:
   - cd %SDK_PREFIX%\bin
+  - set MAPCACHE_CONFIG_FILE=mapcache.xml
+  - set PATH_INFO="/"
+  - set REQUEST_METHOD=GET
+  - set QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image/png&SRS=EPSG:4326&BBOX=0,0,10,10&WIDTH=256&HEIGHT=256&LAYERS=test&TRANSPARENT=TRUE"
   - mapcache.fcgi.exe
   - mapcache_seed.exe
 
 deploy: off
 
 artifacts:
-  - path: "%SDK_PREFIX%\\bin"
+  - path: mapcache.zip
     name: mapcache
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ build_script:
         -DAPR_HAS_LDAP=OFF ^
         -DAPR_BUILD_TESTAPR=OFF ^
         -DINSTALL_PDB=OFF ^
-  - ..\..\apr-util-1.6.1
+  - cd ..\..\apr-util-1.6.1
   - nmake
   - nmake install
 
@@ -94,7 +94,7 @@ build_script:
         -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON ^
         -DPCRE_NEWLINE=CRLF ^
         -DINSTALL_MSVC_PDB=OFF ^
-  - ..\..\%PCRE%
+  - cd ..\..\%PCRE%
   - nmake
   - nmake install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ build_script:
   - if "%platform%" == "x86" SET SDK=release-1800
   - if "%platform%" == "x64" SET SDK=release-1800-x64
   - echo "%VS_FULL%"
-  - if "%platform%" == "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
-  - if "%platform%" == "x86" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars32.bat"
+  - if "%platform%" == "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - if "%platform%" == "x86" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - set SDK_ZIP=%SDK%-dev.zip
   - set SDK_URL=http://download.gisinternals.com/sdk/downloads/%SDK_ZIP%
   - echo "%SDK_ZIP%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -142,6 +142,6 @@ test_script:
 deploy: off
 
 artifacts:
-  - path: mapcache-%APPVEYOR_REPO_BRANCH%.zip
+  - path: mapcache.zip
     name: mapcache
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -142,6 +142,6 @@ test_script:
 deploy: off
 
 artifacts:
-  - path: mapcache.zip
+  - path: '%APPVEYOR_BUILD_FOLDER%\mapcache.zip'
     name: mapcache
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -136,12 +136,12 @@ test_script:
   - set PATH_INFO="/"
   - set REQUEST_METHOD=GET
   - set QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image/png&SRS=EPSG:4326&BBOX=0,0,10,10&WIDTH=256&HEIGHT=256&LAYERS=test&TRANSPARENT=TRUE"
-  - mapcache.fcgi.exe
-  - mapcache_seed.exe
+  - mapcache.fcgi.exe > nul
+  - mapcache_seed.exe > nul
 
 deploy: off
 
 artifacts:
-  - path: mapcache.zip
+  - path: mapcache-%APPVEYOR_REPO_BRANCH%.zip
     name: mapcache
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,14 +43,14 @@ build_script:
   - cd build-cmake
   - mkdir apr
   - cd apr
-  - cmake -G "NMake Makefiles" ^
-        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% ^
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
-        -DMIN_WINDOWS_VER=0x0600 ^
-        -DAPR_HAVE_IPV6=ON ^
-        -DAPR_INSTALL_PRIVATE_H=ON ^
-        -DAPR_BUILD_TESTAPR=OFF ^
-        -DAPU_HAVE_ODBC=OFF ^
+  - cmake -G "NMake Makefiles" 
+        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% 
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo 
+        -DMIN_WINDOWS_VER=0x0600 
+        -DAPR_HAVE_IPV6=ON 
+        -DAPR_INSTALL_PRIVATE_H=ON 
+        -DAPR_BUILD_TESTAPR=OFF 
+        -DAPU_HAVE_ODBC=OFF 
         -DINSTALL_PDB=OFF ..\..\apr-1.6.3
   - nmake
   - nmake install
@@ -61,16 +61,17 @@ build_script:
   - 7z x apr-util-1.6.1-win32-src.zip
   - mkdir build-cmake\apr-util
   - cd build-cmake\apr-util
-  - cmake -G "NMake Makefiles" ^
-        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% ^
-        -DOPENSSL_ROOT_DIR=%SDK_PREFIX% ^
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
-        -DAPU_HAVE_CRYPTO=ON ^
-        -DAPU_HAVE_ODBC=OFF ^
-        -DAPR_HAS_LDAP=OFF ^
-        -DAPR_BUILD_TESTAPR=OFF ^
-        -DINSTALL_PDB=OFF ^
+  - cmake -G "NMake Makefiles" 
+        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% 
+        -DOPENSSL_ROOT_DIR=%SDK_PREFIX% 
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo 
+        -DAPU_HAVE_CRYPTO=ON 
+        -DAPU_HAVE_ODBC=OFF 
+        -DAPR_HAS_LDAP=OFF 
+        -DAPR_BUILD_TESTAPR=OFF 
+        -DINSTALL_PDB=OFF 
   - cd ..\..\apr-util-1.6.1
+  - echo %CD%
   - nmake
   - nmake install
 
@@ -82,18 +83,18 @@ build_script:
   - 7z x %PCRE%.zip > nul
   - mkdir build-cmake\pcre
   - cd build-cmake\pcre
-  - cmake -G "NMake Makefiles" ^
-        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% ^
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
-        -DBUILD_SHARED_LIBS=ON ^
-        -DPCRE_BUILD_TESTS=OFF ^
-        -DPCRE_BUILD_PCRECPP=OFF ^
-        -DPCRE_BUILD_PCREGREP=OFF ^
-        -DPCRE_SUPPORT_PCREGREP_JIT=OFF ^
-        -DPCRE_SUPPORT_UTF=ON ^
-        -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON ^
-        -DPCRE_NEWLINE=CRLF ^
-        -DINSTALL_MSVC_PDB=OFF ^
+  - cmake -G "NMake Makefiles" 
+        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% 
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo 
+        -DBUILD_SHARED_LIBS=ON 
+        -DPCRE_BUILD_TESTS=OFF 
+        -DPCRE_BUILD_PCRECPP=OFF 
+        -DPCRE_BUILD_PCREGREP=OFF 
+        -DPCRE_SUPPORT_PCREGREP_JIT=OFF 
+        -DPCRE_SUPPORT_UTF=ON 
+        -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON 
+        -DPCRE_NEWLINE=CRLF 
+        -DINSTALL_MSVC_PDB=OFF 
   - cd ..\..\%PCRE%
   - nmake
   - nmake install
@@ -109,11 +110,11 @@ build_script:
 
   - mkdir build
   - cd build
-  - cmake -G "%VS_FULL%" ^
-        -DWITH_APACHE=OFF ^
-        -DWITH_FCGI=ON ^
-        -DWITH_PCRE=ON ^
-        -DWITH_TIFF=OFF ^
+  - cmake -G "%VS_FULL%" 
+        -DWITH_APACHE=OFF 
+        -DWITH_FCGI=ON 
+        -DWITH_PCRE=ON 
+        -DWITH_TIFF=OFF 
         -DCMAKE_PREFIX_PATH=%SDK_PREFIX% ..
   - cmake --build . --config Release
 


### PR DESCRIPTION
This pull request adds an appveyor.yaml file to the project, and builds a Windows VS 2017 x64 .DLL and FastCGI exe. The required dependencies not in the GisInternals SDKs are also built from source (thanks to @gfenoy / Zoo Project for build code). 

This can be used alongside the [1911 ](http://www.gisinternals.com/query.html?content=filelist&file=release-1911-x64-gdal-2-2-mapserver-7-0.zip )releases from http://www.gisinternals.com and is a useful test for any Windows related breaking changes. 
