### PR TITLE
Use RST for README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@
  * Author:   Thomas Bonfort and the MapServer team.
  *
  ******************************************************************************
- * Copyright (c) 1996-2012 Regents of the University of Minnesota.
+ * Copyright (c) 1996-2018 Regents of the University of Minnesota.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/README
+++ b/README
@@ -1,2 +1,0 @@
-new code repository is at https://github.com/mapserver/mapcache
-

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,31 @@
+MapCache
+========
+
+| |Build Status| |Appveyor Build Status|
+
+-------
+Summary
+-------
+
+MapCache is a server that implements tile caching to speed up access to WMS layers. The primary objectives are to be fast and easily deployable, 
+while offering the essential features (and more!) expected from a tile caching solution.
+
+For more  information and complete documentation please 
+visit:
+
+  http://mapserver.org/mapcache/
+  
+Questions relating to MapCache use and development can be asked on the MapServer mailing lists:
+
+  http://www.mapserver.org/community/lists.html  
+  
+License
+-------
+
+.. include:: LICENSE
+
+.. |Build Status| image:: https://travis-ci.org/mapserver/mapcache.svg?branch=master
+   :target: https://travis-ci.org/mapserver/mapcache
+
+.. |Appveyor Build Status| image:: https://ci.appveyor.com/api/projects/status/7al5utxjh83ig71v?svg=true
+   :target: https://ci.appveyor.com/project/mapserver/mapcache

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,36 @@ Questions relating to MapCache use and development can be asked on the MapServer
 License
 -------
 
-.. include:: LICENSE
+::
+
+	/******************************************************************************
+	 *
+	 * Project:  MapServer
+	 * Purpose:  MapCache tile caching program.
+	 * Author:   Thomas Bonfort and the MapServer team.
+	 *
+	 ******************************************************************************
+	 * Copyright (c) 1996-2018 Regents of the University of Minnesota.
+	 *
+	 * Permission is hereby granted, free of charge, to any person obtaining a
+	 * copy of this software and associated documentation files (the "Software"),
+	 * to deal in the Software without restriction, including without limitation
+	 * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+	 * and/or sell copies of the Software, and to permit persons to whom the
+	 * Software is furnished to do so, subject to the following conditions:
+	 *
+	 * The above copyright notice and this permission notice shall be included in
+	 * all copies of this Software or works derived from this Software.
+	 *
+	 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	 * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+	 * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+	 * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+	 * DEALINGS IN THE SOFTWARE.
+	 *****************************************************************************/
+
 
 .. |Build Status| image:: https://travis-ci.org/mapserver/mapcache.svg?branch=master
    :target: https://travis-ci.org/mapserver/mapcache


### PR DESCRIPTION
Similar to the recent update to MapServer this pull request uses restructured text so the README file is nicely formatted on Github where it is likely to be most seen. 

The LICENSE file can't be included directly due to Github security reasons, so was manually added in to match the MapServer format. 

A preview can be seen at https://github.com/geographika/mapcache/tree/rst-index

I also bumped the LICENSE year from 2012 to 2018 - presumably this is ok?