### PR TITLE
Add :inv_x and :inv_y to templates available in SQLite queries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ build_script:
 
   - cd %APPVEYOR_BUILD_FOLDER%
 
-  - if not exist apr-util-1.6.1-win32-src.zip appveyor DownloadFile http://apache.mindstudios.com/apr/apr-util-1.6.1-win32-src.zip
+  - if not exist apr-util-1.6.1-win32-src.zip appveyor DownloadFile https://archive.apache.org/dist/apr/apr-util-1.6.1-win32-src.zip
   - 7z x apr-util-1.6.1-win32-src.zip
   - mkdir build-cmake\apr-util
   - cd build-cmake\apr-util

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
   - set SDK_BIN=%CD%\sdk\%SDK%\bin
   - set REGEX_DIR=%CD%\sdk\regex-0.12
 
-  - if not exist apr-1.6.3-win32-src.zip appveyor DownloadFile http://apache.mindstudios.com/apr/apr-1.6.3-win32-src.zip
+  - if not exist apr-1.6.3-win32-src.zip appveyor DownloadFile https://archive.apache.org/dist/apr/apr-1.6.3-win32-src.zip
   - 7z x apr-1.6.3-win32-src.zip
   - mkdir build-cmake
   - cd build-cmake

--- a/lib/cache_sqlite.c
+++ b/lib/cache_sqlite.c
@@ -296,11 +296,19 @@ static void _bind_sqlite_params(mapcache_context *ctx, void *vstmt, mapcache_cac
   paramidx = sqlite3_bind_parameter_index(stmt, ":x");
   if (paramidx) sqlite3_bind_int(stmt, paramidx, tile->x);
 
+  paramidx = sqlite3_bind_parameter_index(stmt, ":inv_x");
+  if (paramidx)
+    sqlite3_bind_int(stmt, paramidx, tile->grid_link->grid->levels[tile->z]->maxx - tile->x - 1);
+
   /* tile->y */
   paramidx = sqlite3_bind_parameter_index(stmt, ":y");
   if (paramidx) sqlite3_bind_int(stmt, paramidx, tile->y);
 
-  /* tile->y */
+  paramidx = sqlite3_bind_parameter_index(stmt, ":inv_y");
+  if (paramidx)
+    sqlite3_bind_int(stmt, paramidx, tile->grid_link->grid->levels[tile->z]->maxy - tile->y - 1);
+
+  /* tile->z */
   paramidx = sqlite3_bind_parameter_index(stmt, ":z");
   if (paramidx) sqlite3_bind_int(stmt, paramidx, tile->z);
 


### PR DESCRIPTION
Like with disk cache [template structure](https://mapserver.org/mapcache/caches.html#template-structure) which uses _{inv_x}_ and _{inv_y}_ to support grids where one axis is inverted (e.g. the google schema), this pull request implements _:inv_x_ and _:inv_y_ in  SQLite cache [custom schema](https://mapserver.org/mapcache/caches.html#custom-schema).
