### PR TITLE
call OpenLayers throught HTTPS

### DIFF
--- a/lib/service_demo.c
+++ b/lib/service_demo.c
@@ -57,7 +57,7 @@ static char *demo_head =
   "        padding: 0px;\n"
   "    }\n"
   "    </style>\n"
-  "    <script src=\"http://www.openlayers.org/api/OpenLayers.js\"></script>\n"
+  "    <script src=\"https://www.openlayers.org/api/OpenLayers.js\"></script>\n"
   "    <script type=\"text/javascript\">\n"
   "%s\n"
   "var map;\n"


### PR DESCRIPTION
Will avoid mixed content errors when your service is deployed with HTTPS (which it should be). And won't be no harm if still HTTP.