### PR TITLE
Fix issue with PostgreSQL 2nd level dimensions

### DIFF
--- a/lib/dimension_pg.c
+++ b/lib/dimension_pg.c
@@ -104,6 +104,7 @@ static void _mapcache_dimension_postgresql_bind_parameters(mapcache_context *ctx
 
   paramidx = VOIDP2INT(apr_hash_get(param_indexes,":dim",APR_HASH_KEY_STRING));
   if (paramidx) {
+    paramidx-=1;
     (*paramValues)[paramidx] = dim_value;
     (*paramLengths)[paramidx] = strlen(dim_value);
     (*paramFormats)[paramidx] = 0;


### PR DESCRIPTION
This pull request aims at fixing a bug that prevents [PostgreSQL dimensions](https://mapserver.org/mapcache/dimensions.html#postgresql-dimensions) from working correctly.