### PR TITLE
Image merge optimization

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1535,6 +1535,11 @@ void _mapcache_imageio_jpeg_decode_to_image(mapcache_context *ctx, mapcache_buff
 mapcache_image_format_type mapcache_imageio_header_sniff(mapcache_context *ctx, mapcache_buffer *buffer);
 
 /**
+ * \brief lookup the first few bytes of a buffer to check for alpha channel
+ */
+mapcache_image_alpha_type mapcache_imageio_alpha_sniff(mapcache_context *ctx, mapcache_buffer *buffer);
+
+/**
  * \brief checks if the given buffer is a recognized image format
  */
 int mapcache_imageio_is_valid_format(mapcache_context *ctx, mapcache_buffer *buffer);

--- a/lib/imageio.c
+++ b/lib/imageio.c
@@ -62,24 +62,37 @@ mapcache_image_alpha_type mapcache_imageio_alpha_sniff(mapcache_context *ctx, ma
 {
   const unsigned char * b = buffer->buf;
   mapcache_image_format_type t = mapcache_imageio_header_sniff(ctx,buffer);
-  if (t==GC_JPEG) {
-    // A JPG file is opaque
-    return MC_ALPHA_NO;
-  } else if (t==GC_PNG && buffer->size >= 26 && (b[12]|32) == 'i' && (b[13]|32) == 'h' && (b[14]|32) == 'd' && (b[15]|32) == 'r') {
-    // Check color type of PNG file in IHDR chunk
-    if (b[25] == 0 || b[25] == 2) {
-      // Gray or RGB without alpha
-      return MC_ALPHA_NO;
-    } else if (b[25] == 4 || b[25] == 6) {
-      // Gray or RGB with alpha
-      return MC_ALPHA_YES;
-    } else {
-      // TODO: Should check palette index
-      return MC_ALPHA_UNKNOWN;
-    }
-  } else {
-    return MC_ALPHA_UNKNOWN;
+  mapcache_image_alpha_type alpha_type;
+
+  switch (t) {
+    case GC_JPEG:
+      // JPEG files are opaque
+      alpha_type = MC_ALPHA_NO;
+      break;
+    case GC_PNG:
+      if (buffer->size >= 26) {
+        // Check color type of PNG file in IHDR chunk
+        if ( (b[12]|32)=='i' && (b[13]|32)=='h' && (b[14]|32)=='d' && (b[15]|32)=='r' ) {
+          switch (b[25]) {
+            case 4:
+            case 6:
+              // Gray or RGB with alpha
+              alpha_type = MC_ALPHA_YES;
+              break;
+            default:
+              // Other colortypes have no alpha channel
+              alpha_type = MC_ALPHA_NO;
+          }
+        }
+      } else {
+        alpha_type = MC_ALPHA_UNKNOWN;
+      }
+      break;
+    default:
+      alpha_type = MC_ALPHA_UNKNOWN;
+      break;
   }
+  return alpha_type;
 }
 
 mapcache_image* mapcache_imageio_decode(mapcache_context *ctx, mapcache_buffer *buffer)

--- a/lib/imageio_jpeg.c
+++ b/lib/imageio_jpeg.c
@@ -243,6 +243,7 @@ void _mapcache_imageio_jpeg_decode_to_image(mapcache_context *r, mapcache_buffer
     return;
   }
 
+  img->has_alpha = MC_ALPHA_NO;
   jpeg_read_header(&cinfo, TRUE);
   jpeg_start_decompress(&cinfo);
   img->w = cinfo.output_width;

--- a/lib/imageio_png.c
+++ b/lib/imageio_png.c
@@ -408,6 +408,7 @@ void _mapcache_imageio_png_decode_to_image(mapcache_context *ctx, mapcache_buffe
     unsigned char pixel[4];
     uint8_t  alpha;
     unsigned char *pixptr = row_pointers[i];
+    img->has_alpha = MC_ALPHA_NO;
     for(j=0; j<img->w; j++) {
 
       memcpy (pixel, pixptr, sizeof (uint32_t));
@@ -417,10 +418,12 @@ void _mapcache_imageio_png_decode_to_image(mapcache_context *ctx, mapcache_buffe
         pixptr[1] = pixel[1];
         pixptr[2] = pixel[0];
       } else if (alpha == 0) {
+        img->has_alpha = MC_ALPHA_YES;
         pixptr[0] = 0;
         pixptr[1] = 0;
         pixptr[2] = 0;
       } else {
+        img->has_alpha = MC_ALPHA_YES;
         PREMULTIPLY(pixptr[0],pixel[2],alpha);
         PREMULTIPLY(pixptr[1],pixel[1],alpha);
         PREMULTIPLY(pixptr[2],pixel[0],alpha);

--- a/lib/tileset.c
+++ b/lib/tileset.c
@@ -903,8 +903,8 @@ void mapcache_tileset_tile_set_get_with_subdimensions(mapcache_context *ctx, map
         if(GC_HAS_ERROR(ctx))
           goto cleanup;
       }
-      if((subtile->encoded_data && mapcache_imageio_header_sniff(ctx,subtile->encoded_data) == GC_JPEG)||
-         (subtile->raw_image && subtile->raw_image->has_alpha == MC_ALPHA_NO)) {
+      if ((mapcache_imageio_alpha_sniff(ctx,subtile->encoded_data) == MC_ALPHA_NO) ||
+          (subtile->raw_image && subtile->raw_image->has_alpha == MC_ALPHA_NO)) {
         /* the returned image is fully opaque, we don't need to get/decode/merge any further subtiles */
         if(assembled_image)
           assembled_image->has_alpha = MC_ALPHA_NO;


### PR DESCRIPTION
This pull request implements an optimization on image assembly with subdimensions.

The general algorithm stops assembling tiles as soon as the tile just added to the stack is opaque.

Up to now, only JPEG tiles were considered opaque. With this pull request, PNG tiles without alpha channel are taken into account as well.