### PR TITLE
Fix issue regarding subdimensions in multithread WMS context

### DIFF
--- a/lib/core.c
+++ b/lib/core.c
@@ -379,7 +379,7 @@ mapcache_map* mapcache_assemble_maps(mapcache_context *ctx, mapcache_map **maps,
     int j;
     for(j=0; j<nmaptiles[i]; j++) {
       tiles[ntiles] = maptiles[i][j];
-      tiles[ntiles]->dimensions = maps[i]->dimensions;
+      tiles[ntiles]->dimensions = mapcache_requested_dimensions_clone(ctx->pool, maps[i]->dimensions);
       ntiles++;
     }
   }


### PR DESCRIPTION
When requesting a map with WMS, all tiles used to build that map share the same `dimensions` field variable. When using second-level dimensions and `<threaded_fetching>`, this causes issues in the resulting assembled tiles.

This pull request fixes these issues.