### PR TITLE
Fix example list_query for postgresql time dimension

### DIFF
--- a/mapcache.xml
+++ b/mapcache.xml
@@ -57,7 +57,7 @@
 		  <dimension name="dim1" type="postgresql" default="d1" time="true">
 			  <connection>host=localhost user=mapcache password=mapcache dbname=mapcache port=5433</connection>
 			  <validate_query>select to_char(ts,'YYYY-MM-DD"T"HH24:MI:SS"Z"') from timedims where tileset=:tileset and ts&gt;=to_timestamp(:start_timestamp) and ts&lt;=to_timestamp(:end_timestamp) order by ts desc</validate_query>
-			  <list_query>select ts from timedims where tileset=:tileset</list_query>
+			  <list_query>select to_char(ts,'YYYY-MM-DD"T"HH24:MI:SS"Z"') from timedims where tileset=:tileset</list_query>
 		  </dimension>
 	  </dimensions>
    </tileset>


### PR DESCRIPTION
Addresses #228 and https://github.com/mapserver/docs/pull/304.

Like the above issue and pull request mention, I think this needs to be changed to produce a valid `demo` service. I'm not sure if `list_query` is used anywhere else and I'm not sure where `mapcache.xml` is used besides as an example.