### PR TITLE
add Github sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# point to OSGeo sponsor page
+github: [OSGeo]
+# point to PayPal directly
+custom: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MS7JAL9R268D2


### PR DESCRIPTION
 - similar to the MapServer repository changes recently, this (should) add a "Sponsor" button to the "mapcache" Github page
 - funds will go to the OSGeo bank accounts, through MapServer, and targeted as "MapCache"