### PR TITLE
Add HTTP headers to ctx object in FastCGI executable

### DIFF
--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -253,7 +253,7 @@ static void set_headers(mapcache_context* ctx, char** env)
         // convert HTTP header keys from the form HTTP_MY_HEADER to MY-HEADER
         key = apr_strtok(kvp, "=", &pair);
         key = mapcache_util_str_replace(ctx->pool, key, "HTTP_", "");
-        key = mapcache_util_str_replace_all(ctx->pool, apr_pstrdup(ctx->pool, key), "_", "-");
+        //key = mapcache_util_str_replace_all(ctx->pool, key, "_", "-");
 
         val = apr_strtok(NULL, "=", &pair);
 

--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -242,6 +242,43 @@ failed_load:
 
 }
 
+static void set_headers(mapcache_context* ctx, char** env)
+{
+    // add all environ settings including HTTP headers to
+    // a ctx->headers_in apr_table_t
+
+    char* key, * val, * kvp, * pair;
+    int i;
+    int num_env_var;
+
+    num_env_var = 0;
+    while (env[num_env_var] != NULL)
+        num_env_var++;
+
+    apr_table_t* headers;
+    headers = apr_table_make(ctx->pool, num_env_var);
+
+    for (i = 0; env[i] != NULL; i++) {
+        kvp = env[i];
+
+        // convert HTTP header keys from the form HTTP_MY_HEADER to MY-HEADER
+        key = apr_strtok(kvp, "=", &pair);
+        key = mapcache_util_str_replace(ctx->pool, key, "HTTP_", "");
+        key = mapcache_util_str_replace(ctx->pool, key, "_", "-");
+        // key = str_replace_all(ctx->pool, key, "_", "-");
+        val = apr_strtok(NULL, "=", &pair);
+
+        if (val != NULL) {
+            apr_table_addn(headers, key, val);
+        }
+        else {
+            apr_table_addn(headers, key, "");
+        }
+    }
+
+    ctx->headers_in = headers;
+}
+
 int main(int argc, const char **argv)
 {
   mapcache_context_fcgi* globalctx;
@@ -311,40 +348,7 @@ int main(int argc, const char **argv)
       goto cleanup;
     }
 
-    // add all environ settings including HTTP headers to
-    // a ctx->headers_in apr_table_t
-
-    int num_env_var = 0;
-    char** env = environ;
-
-    while (env[num_env_var] != NULL)
-        num_env_var++;
-
-    apr_table_t* headers;
-    headers = apr_table_make(ctx->pool, num_env_var);
-
-    char *key, *val, * kvp, *pair;
-    int i;
-
-    for (i = 0; env[i] != NULL; i++) {
-        kvp = env[i];
-
-        // convert HTTP header keys from the form HTTP_MY_HEADER to MY-HEADER
-        key = apr_strtok(kvp, "=", &pair);
-        key = mapcache_util_str_replace(ctx->pool, key, "HTTP_", "");
-        key = mapcache_util_str_replace(ctx->pool, key, "_", "-");
-        // key = str_replace_all(ctx->pool, key, "_", "-");
-        val = apr_strtok(NULL, "=", &pair);
-
-        if (val != NULL) {
-            apr_table_addn(headers, key, val);
-        }
-        else {
-            apr_table_addn(headers, key, "");
-        }
-    }
-
-    ctx->headers_in = headers;
+    set_headers(ctx, environ);
 
     http_response = NULL;
     if(request->type == MAPCACHE_REQUEST_GET_CAPABILITIES) {

--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -236,7 +236,7 @@ static void set_headers(mapcache_context* ctx, char** env)
     // add all environ settings including HTTP headers to
     // a ctx->headers_in apr_table_t
 
-    char* key, * val, * kvp, * pair;
+    char * key, * val, * kvp, * pair;
     int i;
     int num_env_var;
     apr_table_t* headers;
@@ -253,7 +253,8 @@ static void set_headers(mapcache_context* ctx, char** env)
         // convert HTTP header keys from the form HTTP_MY_HEADER to MY-HEADER
         key = apr_strtok(kvp, "=", &pair);
         key = mapcache_util_str_replace(ctx->pool, key, "HTTP_", "");
-        key = mapcache_util_str_replace_all(ctx->pool, key, "_", "-");
+        key = mapcache_util_str_replace_all(ctx->pool, apr_pstrdup(ctx->pool, key), "_", "-");
+
         val = apr_strtok(NULL, "=", &pair);
 
         if (val != NULL) {

--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -162,17 +162,6 @@ static void fcgi_write_response(mapcache_context_fcgi *ctx, mapcache_http_respon
   }
 }
 
-// Replace all occurrences of substr in string
-char* str_replace_all(apr_pool_t* pool, const char* string,
-    const char* substr, const char* replacement)
-{
-    char* replaced = apr_pstrdup(pool, string);
-    while (strstr(replaced, substr)) {
-        replaced = mapcache_util_str_replace(pool, string, substr, replacement);
-    }
-    return replaced;
-}
-
 apr_time_t mtime;
 char *conffile;
 
@@ -264,8 +253,7 @@ static void set_headers(mapcache_context* ctx, char** env)
         // convert HTTP header keys from the form HTTP_MY_HEADER to MY-HEADER
         key = apr_strtok(kvp, "=", &pair);
         key = mapcache_util_str_replace(ctx->pool, key, "HTTP_", "");
-        key = mapcache_util_str_replace(ctx->pool, key, "_", "-");
-        // key = str_replace_all(ctx->pool, key, "_", "-");
+        key = mapcache_util_str_replace_all(ctx->pool, key, "_", "-");
         val = apr_strtok(NULL, "=", &pair);
 
         if (val != NULL) {
@@ -348,7 +336,7 @@ int main(int argc, const char **argv)
       goto cleanup;
     }
 
-    set_headers(ctx, environ);
+    set_headers(ctx, apr_pstrdup(ctx->pool, environ));
 
     http_response = NULL;
     if(request->type == MAPCACHE_REQUEST_GET_CAPABILITIES) {

--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -248,12 +248,12 @@ static void set_headers(mapcache_context* ctx, char** env)
     headers = apr_table_make(ctx->pool, num_env_var);
 
     for (i = 0; env[i] != NULL; i++) {
-        kvp = env[i];
+        kvp = apr_pstrdup(ctx->pool, env[i]);
 
         // convert HTTP header keys from the form HTTP_MY_HEADER to MY-HEADER
         key = apr_strtok(kvp, "=", &pair);
         key = mapcache_util_str_replace(ctx->pool, key, "HTTP_", "");
-        //key = mapcache_util_str_replace_all(ctx->pool, key, "_", "-");
+        key = mapcache_util_str_replace_all(ctx->pool, key, "_", "-");
 
         val = apr_strtok(NULL, "=", &pair);
 
@@ -337,7 +337,7 @@ int main(int argc, const char **argv)
       goto cleanup;
     }
 
-    set_headers(ctx, apr_pstrdup(ctx->pool, environ));
+    set_headers(ctx, environ);
 
     http_response = NULL;
     if(request->type == MAPCACHE_REQUEST_GET_CAPABILITIES) {

--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -250,12 +250,12 @@ static void set_headers(mapcache_context* ctx, char** env)
     char* key, * val, * kvp, * pair;
     int i;
     int num_env_var;
+    apr_table_t* headers;
 
     num_env_var = 0;
     while (env[num_env_var] != NULL)
         num_env_var++;
 
-    apr_table_t* headers;
     headers = apr_table_make(ctx->pool, num_env_var);
 
     for (i = 0; env[i] != NULL; i++) {

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1442,7 +1442,7 @@ MS_DLL_EXPORT char *mapcache_util_str_replace(apr_pool_t *pool, const char *stri
                                 const char *replacement );
 char *mapcache_util_dbl_replace(apr_pool_t *pool, const char *string, const char *substr,
                                 double replacement );
-char *mapcache_util_str_replace_all(apr_pool_t *pool, const char *string, const char *substr,
+MS_DLL_EXPORT char *mapcache_util_str_replace_all(apr_pool_t *pool, const char *string, const char *substr,
                                     const char *replacement );
 char *mapcache_util_dbl_replace_all(apr_pool_t *pool, const char *string, const char *substr,
                                     double replacement );


### PR DESCRIPTION
Initial attempt at resolving #256 and providing the same HTTP header forwarding functionality as the Apache module. 
Tested and working on IIS as a FastCGI module. 

For each request the environ is looped through (note this is the FastCGI environment rather than the system environment (see [MapServer discussions here](https://github.com/MapServer/MapServer/pull/6290). 

There seems to be no way to know which server variables are HTTP headers and what are other variables. 

HTTP headers are saved as server variables in the format "HTTP_MY_HEADER", but are expected to be available as "MY-HEADER". The code attempts to set this. I took a copy of the `str_replace_all` function from: https://github.com/MapServer/mapcache/blob/447c0c6848fd101c11e6d54e451037e571117ef1/contrib/mapcache_detail/mapcache_detail.c#L387 (if it works this function could perhaps be moved to the `util.c` file?). 

This was an attempt to replace all instances of "_" with "-".  However it seemed to send the server into an infinite loop. 

I tried to stay with the approach used in the rest of MapCache, mainly by searching and copying, so code reviews very welcome..!