### PR TITLE
Allow environment variables to be set in config file

### DIFF
--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -60,6 +60,16 @@ void parseMetadata(mapcache_context *ctx, ezxml_t node, apr_table_t *metadata)
   }
 }
 
+void parseEnvironment(mapcache_context* ctx, ezxml_t node)
+{
+    ezxml_t cur_node;
+    for (cur_node = node->child; cur_node; cur_node = cur_node->ordered) {
+        if (!cur_node->child) {
+            putenv(apr_psprintf(ctx->pool, "%s=%s", cur_node->name, cur_node->txt));
+        }
+    }
+}
+
 void parseDimensions(mapcache_context *ctx, ezxml_t node, mapcache_tileset *tileset)
 {
   ezxml_t dimension_node;
@@ -1263,6 +1273,11 @@ void mapcache_configuration_parse_xml(mapcache_context *ctx, const char *filenam
   for(node = ezxml_child(doc,"metadata"); node; node = node->next) {
     parseMetadata(ctx, node, config->metadata);
     if(GC_HAS_ERROR(ctx)) goto cleanup;
+  }
+
+  for (node = ezxml_child(doc, "environment"); node; node = node->next) {
+      parseEnvironment(ctx, node);
+      if (GC_HAS_ERROR(ctx)) goto cleanup;
   }
 
   for(node = ezxml_child(doc,"source"); node; node = node->next) {

--- a/lib/http.c
+++ b/lib/http.c
@@ -104,10 +104,16 @@ void mapcache_http_do_request(mapcache_context *ctx, mapcache_http *req, mapcach
   CURL *curl_handle;
   char error_msg[CURL_ERROR_SIZE];
   int ret;
+  const char* ca_bundle = NULL;
   struct curl_slist *curl_headers=NULL;
   struct _header_struct h;
   curl_handle = curl_easy_init();
 
+  ca_bundle = getenv("CURL_CA_BUNDLE");
+
+  if (ca_bundle) {
+    curl_easy_setopt(curl_handle, CURLOPT_CAINFO, ca_bundle);
+  }
 
   /* specify URL to get */
   curl_easy_setopt(curl_handle, CURLOPT_URL, req->url);
@@ -133,7 +139,6 @@ void mapcache_http_do_request(mapcache_context *ctx, mapcache_http *req, mapcach
   curl_easy_setopt(curl_handle, CURLOPT_CONNECTTIMEOUT, req->connection_timeout);
   curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT, req->timeout);
   curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1);
-
 
 
   if(req->headers) {

--- a/mapcache.xml.sample
+++ b/mapcache.xml.sample
@@ -15,6 +15,17 @@
       -->
    </metadata>
 
+  <environment>
+    
+    <!--
+    
+           environment variables can be set and overridden here
+           this is useful on Windows servers to set a path
+           to a certificates file when connecting to sources using HTTPS
+
+    <CURL_CA_BUNDLE>C:/MapServer/bin/curl-ca-bundle.crt</CURL_CA_BUNDLE>
+    -->
+  </environment>
    <!--
         a grid represents the layout of tiles: srs, extent, resolutions, and tile size
    -->
@@ -30,7 +41,7 @@
       <!--
            Set to "true" if no new tiles should be created when not in
            the configured cache. If a requested tile is not present in
-           a read-only cache, it wil be returned as "nodata", i.e. fully
+           a read-only cache, it will be returned as "nodata", i.e. fully
            transparent in a vertical assembly case, or as a 404 in a
            single-tile case.
            Note that the read-only status of a tileset is overridden to
@@ -84,7 +95,7 @@
 
    <!--
          there are three preconfigured grids you can use in <tileset>s without having to
-         explicitely define them here:
+         explicitly define them here:
          <grid name="WGS84">
             <metadata>
                <title>GoogleCRS84Quad</title>
@@ -361,7 +372,7 @@
           Similar to symlink_blank, except completely skip writing a file
           if a blank, fully transparent tile is detected.
           Note: This setting should only be used when using the seeder.  If used
-          on demand, mapcache will will query the WMS source on each subsequent 
+          on demand, mapcache will query the WMS source on each subsequent 
           tile request.
       -->
       <detect_blank/>
@@ -385,7 +396,7 @@
          * note that this type of cache does not support blank-tile detection and symlinking.
       
          * warning: it is up to you to make sure that the template you chose creates a unique
-           filename for your given tilesets. e.g. do not ommit the {grid} parameter if your
+           filename for your given tilesets. e.g. do not omit the {grid} parameter if your
            tilesets reference multiple grids. Failure to do so will result in filename
            collisions ! 
 
@@ -396,7 +407,7 @@
           Similar to symlink_blank, except completely skip writing a file
           if a blank, fully transparent tile is detected.
           Note: This setting should only be used when using the seeder.  If used
-          on demand, mapcache will will query the WMS source on each subsequent 
+          on demand, mapcache will query the WMS source on each subsequent 
           tile request.
       -->
       <detect_blank/>
@@ -426,10 +437,10 @@
       <dbfile>/tmp/mysqlitetiles.db</dbfile>
 
       <!-- pragma
-           special sqlite pargmas sent to db at connection time. The following
+           special sqlite pragmas sent to db at connection time. The following
            would execute:
            PRAGMA key=value;
-           usefull for changing default values e.g. on large databases.
+           useful for changing default values e.g. on large databases.
 
       -->
       <pragma name="key">value</pragma>
@@ -577,7 +588,7 @@
 
            png compression: best or fast
            note that "best" compression is cpu intensive for little gain over the default
-           default compression is obtained by leving out this tag.
+           default compression is obtained by leaving out this tag.
       -->
       <compression>fast</compression>
 
@@ -681,7 +692,7 @@
          <connection_timeout>30</connection_timeout>
          
          <!-- timeout in seconds before bailing out from a request. This is the total time needed
-              to fullfill the request, and includes the time needed to transfer the response through
+              to fulfill the request, and includes the time needed to transfer the response through
               the network. Defaults to 600 seconds, set to a higher value if e.g. WMS requests for
               large metatiles take longer than 10 minutes to render -->
          <timeout>300</timeout>
@@ -798,7 +809,7 @@
       
       <!-- format
          (optional) format to use when storing a tile. this should be a format with high
-         compression, eg. png with compression "best", as the compression operation is only
+         compression, e.g. png with compression "best", as the compression operation is only
          done once at creation time.
          if left out, no recompression is applied to the image, mod-mapcache will store the
          exact image received from the <source>
@@ -868,8 +879,8 @@
             mapserver mapfiles. the name of the mapfiles need not be known to mod-mapcache, and can therefore be 
             created even after mod-mapcache has been started.
             when a user passes a MAPFILE=/path/to/mapfile, the string "/path/to/mapfile" is validated against
-            the supplied (PCRE) regular expression. The one in this example allows a name composed of aphanumeric characters
-            spearated by slashes (/) and finishing with ".map" ( [a-zA-Z0-9\./]*\.map$ ) , but will faill if there
+            the supplied (PCRE) regular expression. The one in this example allows a name composed of alphanumeric characters
+            separated by slashes (/) and finishing with ".map" ( [a-zA-Z0-9\./]*\.map$ ) , but will fail if there
             are two consecutive dots (..) in the path, to prevent filesystem traversal  ( (?!.*\.\.) ).
          -->
 	 <dimension type="regex" name="MAPFILE" default="/path/to/mapfile.map">


### PR DESCRIPTION
Initial attempt at resolving #251 - by allowing the `CURL_CA_BUNDLE` environment variable to be set in MapCache's XML config file. 

On Windows/IIS FastCGI environment variables set in the IIS config were ignored. 

The pull request adds a new `environment` section to the config file that allows setting and overriding environment variables in the following format:

```xml
  <environment>
    <KEY>value</KEY>
    <CURL_CA_BUNDLE>C:/MapServer/bin/curl-ca-bundle.crt</CURL_CA_BUNDLE>
  </environment>
```

I'm unsure if MapCache on Unix-systems is already able to connect to WMS sources using HTTPS? Without adding the additional cURL option `CURL_CA_BUNDLE` was ignored on Windows. MapServer uses [unchecked_curl_easy_setopt](https://github.com/MapServer/MapServer/blob/7c65ac4256d94e0dcc2870ef6f7ccb549f3b0f70/maphttp.c#L579) (possibly for avoiding [warnings](https://github.com/MapServer/MapServer/commit/897812f8a20427526949cf0100a879760a7972dd#diff-f001c4ce4ec963e442095ba2c6caf05e06a91c5efac970a974eb4050dd5300f3) when setting these options, whereas MapCache uses `curl_easy_setopt`. This can be updated if required. 

This approach has been tested and works on Windows/IIS/FastCGI. 

The `mapcache.xml.sample` was also updated with the new section (plus fixed a few typos). 



