### PR TITLE
Simplify Appveyor Build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,8 +71,7 @@ test_script:
   - set REQUEST_METHOD=GET
   - set QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image/png&SRS=EPSG:4326&BBOX=0,0,10,10&WIDTH=256&HEIGHT=256&LAYERS=test&TRANSPARENT=TRUE"
   - mapcache.fcgi.exe
-  # following returns 1 (error)
-  #- mapcache_seed.exe -h
+  - mapcache_seed.exe -h
 
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,6 @@ build_script:
   - cd sdk
   - appveyor DownloadFile "%SDK_URL%"
   - 7z x "%SDK_ZIP%" > nul
-  - cd %SDK%
-  #- cd lib
-  #- copy libpng.lib libpng.lib.lib
   - cd %APPVEYOR_BUILD_FOLDER%
   - set SDK_PREFIX=%BUILD_FOLDER%/sdk/%SDK%
   - set SDK_INC=%BUILD_FOLDER%/sdk/%SDK%/include
@@ -39,74 +36,12 @@ build_script:
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
   - set REGEX_DIR=%BUILD_FOLDER%/sdk/support/regex-0.12
 
-  - if not exist apr-1.6.3-win32-src.zip appveyor DownloadFile https://archive.apache.org/dist/apr/apr-1.6.3-win32-src.zip
-  - 7z x apr-1.6.3-win32-src.zip
-  - mkdir build-cmake
-  - cd build-cmake
-  - mkdir apr
-  - cd apr
-  - cmake -G "NMake Makefiles" 
-        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% 
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo 
-        -DMIN_WINDOWS_VER=0x0600 
-        -DAPR_HAVE_IPV6=ON 
-        -DAPR_INSTALL_PRIVATE_H=ON 
-        -DAPR_BUILD_TESTAPR=OFF 
-        -DAPU_HAVE_ODBC=OFF 
-        -DINSTALL_PDB=OFF ..\..\apr-1.6.3
-  - nmake
-  - nmake install
-
-  - cd %APPVEYOR_BUILD_FOLDER%
-
-  - if not exist apr-util-1.6.1-win32-src.zip appveyor DownloadFile https://archive.apache.org/dist/apr/apr-util-1.6.1-win32-src.zip
-  - 7z x apr-util-1.6.1-win32-src.zip
-  - mkdir build-cmake\apr-util
-  - cd build-cmake\apr-util
-  - cmake -G "NMake Makefiles" 
-        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% 
-        -DOPENSSL_ROOT_DIR=%SDK_PREFIX% 
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo 
-        -DAPU_HAVE_CRYPTO=ON 
-        -DAPU_HAVE_ODBC=OFF 
-        -DAPR_HAS_LDAP=OFF 
-        -DAPR_BUILD_TESTAPR=OFF 
-        -DINSTALL_PDB=OFF ..\..\apr-util-1.6.1
-  - nmake
-  - nmake install
-
-  - cd %APPVEYOR_BUILD_FOLDER%
-
-  - set PCRE_VERSION=8.38
-  - set PCRE=pcre-%PCRE_VERSION%
-  - if not exist %PCRE%.zip appveyor DownloadFile "http://zoo-project.org/dl/%PCRE%.zip"
-  - 7z x %PCRE%.zip > nul
-  - mkdir build-cmake\pcre
-  - cd build-cmake\pcre
-  - cmake -G "NMake Makefiles" 
-        -DCMAKE_INSTALL_PREFIX=%SDK_PREFIX% 
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo 
-        -DBUILD_SHARED_LIBS=ON 
-        -DPCRE_BUILD_TESTS=OFF 
-        -DPCRE_BUILD_PCRECPP=OFF 
-        -DPCRE_BUILD_PCREGREP=OFF 
-        -DPCRE_SUPPORT_PCREGREP_JIT=OFF 
-        -DPCRE_SUPPORT_UTF=ON 
-        -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON 
-        -DPCRE_NEWLINE=CRLF 
-        -DINSTALL_MSVC_PDB=OFF ..\..\%PCRE%
-  - nmake
-  - nmake install
-
-  - echo %SDK_LIB%
   - cd %SDK_LIB%
-  - dir
   - copy "%SDK_LIB%/libfcgi.lib" "%SDK_LIB%/fcgi.lib" /Y
   - copy "%SDK_LIB%/apr-1.lib" "%SDK_LIB%/apr-1-1.lib" /Y
   - copy "%SDK_LIB%/libapr-1.lib" "%SDK_LIB%/apr-1.lib" /Y > nul
   - copy "%SDK_LIB%/aprutil-1.lib" "%SDK_LIB%/aprutil-1-1.lib" /Y > nul
   - copy "%SDK_LIB%/libaprutil-1.lib" "%SDK_LIB%/aprutil-1.lib" /Y > nul
-  - xcopy "%REGEX_DIR%/*.h" "%SDK_INC%" /O /X /E /H /K /Y > nul
 
   - cd %APPVEYOR_BUILD_FOLDER%
 
@@ -120,29 +55,24 @@ build_script:
         -DCMAKE_PREFIX_PATH=%SDK_PREFIX% ..
   - cmake --build . --config Release
 
-  - copy "%SDK_LIB%\apr-1-1.lib" "%SDK_LIB%\apr-1.lib" /Y > nul
-  - copy "%SDK_LIB%\aprutil-1-1.lib" "%SDK_LIB%\aprutil-1.lib" /Y > nul
-  - copy "%SDK_BIN%\libapr-1.dll" "%SDK_BIN%\apr-1.dll" /Y > nul
-  - copy "%SDK_BIN%\libaprutil-1.dll" "%SDK_BIN%\aprutil-1.dll" /Y > nul
-  - copy "%SDK_BIN%\libfcgi.dll" "%SDK_BIN%\fcgi.dll" /Y > nul
   - copy "Release\*dll" "%SDK_BIN%" /Y > nul
-  - copy "Release\*lib" "%SDK_LIB%" /Y > nul
   - copy "cgi\Release\*exe" "%SDK_BIN%" /Y > nul
   - copy "util\Release\*exe" "%SDK_BIN%" /Y > nul
 
 after_build:
   - cd %SDK_BIN%
-  - 7z a %APPVEYOR_BUILD_FOLDER%\mapcache.zip libapr*.dll apr*.dll pcre.dll pcreposix.dll mapcache.dll 
+  - 7z a %APPVEYOR_BUILD_FOLDER%\mapcache.zip mapcache.dll
         mapcache.fcgi.exe mapcache_seed.exe %APPVEYOR_BUILD_FOLDER%\mapcache.xml
 
 test_script:
   - cd %SDK_BIN%
-  - set MAPCACHE_CONFIG_FILE=mapcache.xml
+  - set MAPCACHE_CONFIG_FILE=%APPVEYOR_BUILD_FOLDER%\mapcache.xml
   - set PATH_INFO="/"
   - set REQUEST_METHOD=GET
   - set QUERY_STRING="SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&FORMAT=image/png&SRS=EPSG:4326&BBOX=0,0,10,10&WIDTH=256&HEIGHT=256&LAYERS=test&TRANSPARENT=TRUE"
-  - rem mapcache.fcgi.exe
-  - rem mapcache_seed.exe
+  - mapcache.fcgi.exe
+  # following returns 1 (error)
+  #- mapcache_seed.exe -h
 
 deploy: off
 

--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -999,7 +999,8 @@ int main(int argc, const char **argv)
   while ((rv = apr_getopt_long(opt, seed_options, &optch, &optarg)) == APR_SUCCESS) {
     switch (optch) {
       case 'h':
-        return usage(argv[0],NULL);
+        usage(argv[0],NULL);
+        return 0;
         break;
       case 'f':
         force = 1;


### PR DESCRIPTION
The original Appveyor build was based on build scripts from the [Zoo Project](http://zoo-project.org/).
Since then @szekerest has updated the [GISInternals SDK build packages](https://www.gisinternals.com/sdk.php) to include MapCache along with the required dependencies. 

This means several interim steps can be removed, and the Widows build script simplified. 
The renaming of some libs (e.g. `copy "%SDK_LIB%/libfcgi.lib" "%SDK_LIB%/fcgi.lib" /Y`) does still seem to be necessary. 
The seeder app was also updated to return a `0` (no error) code when displaying the help, so it could be run (to check it compiled) without causing the build to be marked as failed. 