### PR TITLE
Switch from Travis and AppVeyor to GitHub actions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,79 @@
+name: Build MapCache on Linux
+on: [ push, pull_request ]
+
+jobs:
+
+    build-matrix:
+      strategy:
+        matrix:
+          os: [ ubuntu-18.04, ubuntu-20.04 ]
+          option: [ minimal, default, maximal ]
+      runs-on: ${{ matrix.os }}
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+
+        - name: Install dependencies
+          run: |
+            if [[ 'minimal,default,maximal' =~ ${{ matrix.option }} ]]
+            then
+              sudo apt-get update -y
+              sudo apt-get upgrade -y
+              sudo apt-get install -y libcurl4-openssl-dev apache2-dev
+            fi
+            if [[ 'default,maximal' =~ ${{ matrix.option }} ]]
+            then
+              sudo apt-get install -y libgdal-dev libfcgi-dev libpixman-1-dev
+              sudo apt-get install -y gdal-bin libxml2-utils
+            fi
+            if [[ 'maximal' =~ ${{ matrix.option }} ]]
+            then
+              sudo apt-get install -y libhiredis-dev libdb-dev libmapserver-dev
+            fi
+
+        - name: Build MapCache
+          run: |
+            if [[ 'minimal' == ${{ matrix.option }} ]]
+            then
+              options="-DWITH_SQLITE=OFF \
+                       -DWITH_PIXMAN=OFF \
+                       -DWITH_GDAL=OFF \
+                       -DWITH_APACHE=OFF \
+                       -DWITH_CGI=OFF \
+                       -DWITH_OGR=OFF \
+                       -DWITH_GEOS=OFF \
+                       -DWITH_MAPCACHE_DETAIL=OFF"
+            elif [[ 'default' == ${{ matrix.option }} ]]
+            then
+              options=""
+            elif [[ 'maximal' == ${{ matrix.option }} ]]
+            then
+              options="-DWITH_POSTGRESQL=ON \
+                       -DWITH_BERKELEY_DB=ON \
+                       -DWITH_MEMCACHE=ON \
+                       -DWITH_REDIS=ON \
+                       -DWITH_TIFF=ON \
+                       -DWITH_TIFF_WRITE_SUPPORT=ON \
+                       -DWITH_GEOTIFF=ON \
+                       -DWITH_PCRE=ON \
+                       -DWITH_MAPSERVER=ON \
+                       -DWITH_RIAK=OFF"
+            fi
+            mkdir build
+            cd build
+            cmake ${options} ${{ github.workspace }}
+            make
+            sudo make install
+            sudo ldconfig
+
+        - name: Run tests
+          run: |
+            if [[ 'ubuntu-20.04' == ${{ matrix.os }} ]] \
+               && [[ 'default' == ${{ matrix.option }} ]]
+            then
+              cd ${{ github.workspace }}/tests
+              ./setup.sh
+              ./run.sh
+            else
+              echo No test performed on this target
+            fi

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,117 @@
+name: Build MapCache on Windows
+on: [ push, pull_request ]
+
+jobs:
+
+    build-matrix:
+      strategy:
+        matrix:
+          os: [ windows-2019 ]
+          option: [ default ]
+      runs-on: ${{matrix.os}}
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+
+        - name: Install dependencies
+          run: |
+            Set-Location -Path "${{github.workspace}}"
+            New-Item -Path . -Name "sdk" -ItemType "directory"
+            Set-Location -Path "sdk"
+            curl -O https://download.gisinternals.com/sdk/downloads/release-1928-x64-dev.zip
+            unzip -qq release-1928-x64-dev.zip
+            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            Set-Location -Path "$sdkprefix\lib"
+            Copy-Item -Path "libfcgi.lib" -Destination "fcgi.lib"
+            Copy-Item -Path "apr-1.lib" -Destination "apr-1-1.lib"
+            Copy-Item -Path "libapr-1.lib" -Destination "apr-1.lib"
+            Copy-Item -Path "aprutil-1.lib" -Destination "aprutil-1-1.lib"
+            Copy-Item -Path "libaprutil-1.lib" -Destination "aprutil-1.lib"
+
+        - name: Build MapCache
+          run: |
+            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            Set-Location -Path "${{github.workspace}}"
+            New-Item -Path . -Name "build" -ItemType "directory"
+            Set-Location -Path "build"
+            cmake -DCMAKE_PREFIX_PATH="$sdkprefix" -DWITH_APACHE=OFF -DWITH_FCGI=ON -DWITH_PCRE=ON -DWITH_TIFF=OFF "${{github.workspace}}"
+            cmake --build . --config Release
+            Copy-Item -Destination "$sdkprefix\bin" -Path "Release\mapcache.dll", "cgi\Release\mapcache.fcgi.exe", "util\Release\mapcache_seed.exe", "contrib\mapcache_detail\Release\mapcache_detail.exe"
+            Set-Location -Path "$sdkprefix\bin"
+            Compress-Archive -DestinationPath "${{github.workspace}}\mapcache.zip" -Path "${{github.workspace}}\mapcache.xml", "mapcache.dll", "mapcache.fcgi.exe", "mapcache_seed.exe", "mapcache_detail.exe"
+
+        - name: Upload binary artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: binaries
+            path: mapcache.zip
+            retention-days: 15
+
+        - name: Setup tests
+          run: |
+            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            Set-Location -Path "${{github.workspace}}\build"
+            Copy-Item -Path "..\tests\data\world.tif" -Destination .
+            New-Item -Path "mapcache.xml"
+            Set-Content -Path "mapcache.xml" -Value @"
+            <?xml version=`"1.0`" encoding=`"UTF-8`"?>
+            <mapcache>
+              <source name=`"global-tif`" type=`"gdal`">
+                <data>${{github.workspace}}\build\world.tif</data>
+              </source>
+              <cache name=`"disk`" type=`"disk`">
+                <base>${{github.workspace}}\build</base>
+              </cache>
+              <tileset name=`"global`">
+                <cache>disk</cache>
+                <source>global-tif</source>
+                <grid maxzoom=`"17`">GoogleMapsCompatible</grid>
+                <format>JPEG</format>
+                <metatile>1 1</metatile>
+              </tileset>
+              <locker type=`"disk`">
+                <directory>${{github.workspace}}\build</directory>
+              </locker>
+              <service type=`"wms`" enabled=`"true`"/>
+              <service type=`"wmts`" enabled=`"true`"/>
+              <log_level>debug</log_level>
+            </mapcache>
+            "@
+
+        - name: Run tests
+          run: |
+            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            Set-Location -Path "$sdkprefix\bin"
+            $env:GDAL_DATA = "$sdkprefix\bin\gdal-data"
+            $env:PROJ_LIB = "$sdkprefix\bin\proj7\share"
+            .\mapcache_seed.exe -c "${{github.workspace}}\build\mapcache.xml" -t global --force -z 0,1
+            Copy-Item -Path "${{github.workspace}}\build\global\GoogleMapsCompatible\00\000\000\000\000\000\000.jpg" -Destination "${{github.workspace}}\seed.jpg"
+            $match = (.\gdal\apps\gdalinfo.exe -checksum "${{github.workspace}}\seed.jpg" | Select-String -CaseSensitive -Pattern "Checksum=21336" -Quiet)
+            if ( $match ) {
+              "Success"
+            } else {
+              "Failure: Did not get expected checksum"
+              exit 1
+            }
+            $env:MAPCACHE_CONFIG_FILE = "${{github.workspace}}\build\mapcache.xml"
+            $env:REQUEST_METHOD = "GET"
+            $env:PATH_INFO = "/wmts/1.0.0/global/default/GoogleMapsCompatible/0/0/0.jpg"
+            $env:QUERY_STRING = ""
+            Start-Process -FilePath ".\mapcache.fcgi.exe" -RedirectStandardOutput "${{github.workspace}}\fcgi.jpg" -NoNewWindow -Wait
+            perl.exe -0777 -pi -e 'binmode ARGV;binmode ARGVOUT;s/[A-Z][-:; ,\/=A-Za-z0-9]*\r\n//g;s/\r\n//' "${{github.workspace}}\fcgi.jpg"
+            $match = (.\gdal\apps\gdalinfo.exe -checksum "${{github.workspace}}\fcgi.jpg" | Select-String -CaseSensitive -Pattern "Checksum=21336" -Quiet)
+            if ( $match ) {
+              "Success"
+            } else {
+              "Failure: Did not get expected checksum"
+              exit 1
+            }
+
+        - name: Upload test artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: test-results
+            path: |
+              seed.jpg
+              fcgi.jpg
+            retention-days: 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ if(JPEG_FOUND)
   include_directories(${JPEG_INCLUDE_DIR})
   target_link_libraries(mapcache ${JPEG_LIBRARY})
 else(JPEG_FOUND)
+  report_mandatory_not_found(JPEG)
 endif(JPEG_FOUND)
    
 find_package(CURL)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,20 +7,16 @@ require 'socket'
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
+  config.vm.box = "ubuntu/focal64"
   config.vm.hostname = "mapcache-vagrant"
-
   config.vm.network :forwarded_port, guest: 80, host: 8080
-
   config.vm.provider "virtualbox" do |v|
-     v.customize ["modifyvm", :id, "--memory", 1024, "--cpus", 2]
-     v.customize ["modifyvm", :id, "--ioapic", "on", "--largepages", "off", "--vtxvpid", "off"]
-     v.name = "mapcache-vagrant"
-   end
+    v.customize ["modifyvm", :id, "--memory", 1024, "--cpus", 2]
+    v.customize ["modifyvm", :id, "--ioapic", "on", "--largepages", "off", "--vtxvpid", "off"]
+    v.name = "mapcache-vagrant"
+  end
 
-  config.vm.provision "shell", path: "scripts/vagrant/virtualbox-fix.sh"
   config.vm.provision "shell", path: "scripts/vagrant/packages.sh"
   config.vm.provision "shell", path: "scripts/vagrant/mapcache.sh"
 

--- a/lib/source_mapserver.c
+++ b/lib/source_mapserver.c
@@ -99,7 +99,7 @@ static mapcache_pooled_connection* _mapserver_get_connection(mapcache_context *c
  * \private \memberof mapcache_source_mapserver
  * \sa mapcache_source::render_map()
  */
-void _mapcache_source_mapserver_render_map(mapcache_context *ctx, mapcache_map *map)
+void _mapcache_source_mapserver_render_map(mapcache_context *ctx, mapcache_source *psource, mapcache_map *map)
 {
   errorObj *errors = NULL;
   mapcache_pooled_connection *pc;
@@ -199,7 +199,7 @@ void _mapcache_source_mapserver_query(mapcache_context *ctx, mapcache_source *ps
  * \private \memberof mapcache_source_mapserver
  * \sa mapcache_source::configuration_parse()
  */
-void _mapcache_source_mapserver_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source *source)
+void _mapcache_source_mapserver_configuration_parse_xml(mapcache_context *ctx, ezxml_t node, mapcache_source * source, mapcache_cfg *config)
 {
   ezxml_t cur_node;
   mapcache_source_mapserver *src = (mapcache_source_mapserver*)source;
@@ -247,10 +247,10 @@ mapcache_source* mapcache_source_mapserver_create(mapcache_context *ctx)
   }
   mapcache_source_init(ctx, &(source->source));
   source->source.type = MAPCACHE_SOURCE_MAPSERVER;
-  source->source.render_map = _mapcache_source_mapserver_render_map;
+  source->source._render_map = _mapcache_source_mapserver_render_map;
   source->source.configuration_check = _mapcache_source_mapserver_configuration_check;
   source->source.configuration_parse_xml = _mapcache_source_mapserver_configuration_parse_xml;
-  source->source.query_info = _mapcache_source_mapserver_query;
+  source->source._query_info = _mapcache_source_mapserver_query;
   return (mapcache_source*)source;
 }
 #else

--- a/scripts/vagrant/mapcache.sh
+++ b/scripts/vagrant/mapcache.sh
@@ -5,9 +5,11 @@ export NUMTHREADS
 
 cd /vagrant
 
-mkdir build_vagrant
+mkdir -p build_vagrant
 cd build_vagrant
-cmake -DWITH_MEMCACHE=1 ..
+cmake ..
 
 make -j $NUMTHREADS
 make install
+
+ldconfig

--- a/scripts/vagrant/packages.sh
+++ b/scripts/vagrant/packages.sh
@@ -1,17 +1,9 @@
 #!/bin/sh
 
-sed -i 's#deb http://us.archive.ubuntu.com/ubuntu/#deb mirror://mirrors.ubuntu.com/mirrors.txt#' /etc/apt/sources.list
-
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get install -y python-software-properties
-add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-apt-get update
-apt-get -y upgrade
+apt-get install -y cmake apache2
+apt-get install -y libcurl4-openssl-dev apache2-dev
+apt-get install -y libgdal-dev libfcgi-dev libpixman-1-dev gdal-bin libxml2-utils
 
-# install packages we need
-apt-get install -q -y build-essential pkg-config cmake libgeos-dev rake vim \
-    bison flex libgdal1-dev libproj-dev libpng12-dev libjpeg-dev libfcgi-dev \
-    libcurl4-gnutls-dev apache2-prefork-dev libtiff4-dev libpixman-1-dev \
-    libsqlite3-dev libmemcached-dev

--- a/tests/data/mapcache.conf
+++ b/tests/data/mapcache.conf
@@ -1,0 +1,6 @@
+<IfModule mapcache_module>
+   <Directory /tmp/mc>
+      Require all granted
+   </Directory>
+   MapCacheAlias /mapcache "/tmp/mc/mapcache.xml"
+</IfModule>

--- a/tests/data/mapcache.load
+++ b/tests/data/mapcache.load
@@ -1,0 +1,1 @@
+LoadModule mapcache_module /usr/lib/apache2/modules/mod_mapcache.so

--- a/tests/data/mapcache.xml
+++ b/tests/data/mapcache.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapcache>
+    <source name="global-tif" type="gdal">
+        <data>/tmp/mc/world.tif</data>
+    </source>
+    <cache name="disk" type="disk">
+        <base>/tmp/mc</base>
+    </cache>
+    <tileset name="global">
+        <cache>disk</cache>
+        <source>global-tif</source>
+        <grid maxzoom="17">GoogleMapsCompatible</grid>
+        <format>JPEG</format>
+        <metatile>1 1</metatile>
+    </tileset>
+    <service type="wmts" enabled="true"/>
+    <service type="wms" enabled="true"/>
+    <log_level>debug</log_level>
+</mapcache>

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Project:  MapCache
+# Purpose:  MapCache tests
+# Author:   Even Rouault
+#
+#*****************************************************************************
+# Copyright (c) 2017 Regents of the University of Minnesota.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+#****************************************************************************/
+
+set -e
+
+MAPCACHE_CONF=/tmp/mc/mapcache.xml
+
+sudo rm -rf /tmp/mc/global
+mapcache_seed -c /tmp/mc/mapcache.xml -t global --force -z 0,1
+if gdalinfo -checksum /tmp/mc/global/GoogleMapsCompatible/00/000/000/000/000/000/000.jpg | grep -q Checksum=20250
+then
+  echo Success
+else
+  echo "Failure: Did not get expected checksum"
+  gdalinfo -checksum /tmp/mc/global/GoogleMapsCompatible/00/000/000/000/000/000/000.jpg
+  /bin/false
+fi
+
+sudo rm -rf /tmp/mc/global
+curl -s "http://localhost/mapcache/?SERVICE=WMS&REQUEST=GetCapabilities" | xmllint --format - > /tmp/wms_capabilities.xml
+diff -u /tmp/wms_capabilities.xml expected
+
+curl -s "http://localhost/mapcache/wmts?SERVICE=WMTS&REQUEST=GetCapabilities" | xmllint --format - > /tmp/wmts_capabilities.xml
+diff -u /tmp/wmts_capabilities.xml expected
+
+curl -s "http://localhost/mapcache/wmts/1.0.0/global/default/GoogleMapsCompatible/0/0/0.jpg" > /tmp/0.jpg
+if gdalinfo -checksum /tmp/0.jpg | grep -q Checksum=20250
+then
+  echo Success
+else
+  echo "Failure: Did not get expected checksum"
+  gdalinfo -checksum /tmp/0.jpg
+  /bin/false
+fi
+
+curl -s "http://localhost/mapcache/wmts/1.0.0/global/default/GoogleMapsCompatible/0/0/0.jpg" > /tmp/0_bis.jpg
+diff /tmp/0.jpg /tmp/0_bis.jpg
+

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Project:  MapCache
+# Purpose:  MapCache tests
+# Author:   Even Rouault
+#
+#*****************************************************************************
+# Copyright (c) 2017 Regents of the University of Minnesota.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+#****************************************************************************/
+
+set -e
+
+mkdir -p /tmp/mc
+sudo chmod -R a+rw /tmp/mc
+
+cp data/mapcache.xml data/world.tif /tmp/mc
+
+sudo cp data/mapcache.load data/mapcache.conf /etc/apache2/mods-available
+if [ ! -L /etc/apache2/mods-enabled/mapcache.load ]
+then
+  sudo ln -s ../mods-available/mapcache.load /etc/apache2/mods-enabled
+fi
+if [ ! -L /etc/apache2/mods-enabled/mapcache.conf ]
+then
+  sudo ln -s ../mods-available/mapcache.conf /etc/apache2/mods-enabled
+fi
+
+sudo apache2ctl -k stop
+sudo apache2ctl -k start


### PR DESCRIPTION
The changes proposed in this pull request aim at:
- Upgrading the CI platforms on which builds and basic tests are performed prior merging, from Ubuntu 12.04, 14.04 and 16.04 to Ubuntu 18.04 and 20.04.
- Switching CI providers from Travis and AppVeyor to GitHub Actions.

Vagrantfile also has been upgraded to Ubuntu 20.04.
Some minor bug found along the way have been fixed as well.

Comment are welcomed, in particular from Windows users.
