### PR TITLE
Increase length of line read to handle larger AWS tokens.

### DIFF
--- a/lib/cache_rest.c
+++ b/lib/cache_rest.c
@@ -868,16 +868,16 @@ static void _mapcache_cache_s3_headers_add(mapcache_context *ctx, const char* me
     if((rv=apr_file_open(&f, s3->credentials_file,
                        APR_FOPEN_READ|APR_FOPEN_BUFFERED|APR_FOPEN_BINARY,APR_OS_DEFAULT,
                        ctx->pool)) == APR_SUCCESS) {
-      char line[1024];
-      if( (rv = apr_file_gets(line,1024,f))== APR_SUCCESS) {
+      char line[2048];
+      if( (rv = apr_file_gets(line,2048,f))== APR_SUCCESS) {
         _remove_lineends(line);
         aws_access_key_id = apr_pstrdup(ctx->pool,line);
       }
-      if( (rv = apr_file_gets(line,1024,f))== APR_SUCCESS) {
+      if( (rv = apr_file_gets(line,2048,f))== APR_SUCCESS) {
         _remove_lineends(line);
         aws_secret_access_key = apr_pstrdup(ctx->pool,line);
       }
-      if( (rv = apr_file_gets(line,1024,f))== APR_SUCCESS) {
+      if( (rv = apr_file_gets(line,2048,f))== APR_SUCCESS) {
         _remove_lineends(line);
         aws_security_token = apr_pstrdup(ctx->pool,line);
       }


### PR DESCRIPTION
In the wild I've found tokens of length 1044 coming back from EC2
instance metadata; mapcache will fail to parse these.  This change
doubles the size and fixes the issue.

Note that AWS says "The size of the security token that AWS STS API
operations return is not fixed. We strongly recommend that you make no
assumptions about the maximum size.", so hard to know how big they can get!  See
https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_ResponseElements