### PR TITLE
Add child init hook for cache backends

### DIFF
--- a/apache/mod_mapcache.c
+++ b/apache/mod_mapcache.c
@@ -307,11 +307,17 @@ static int write_http_response(mapcache_context_apache_request *ctx, mapcache_ht
 
 static void mod_mapcache_child_init(apr_pool_t *pool, server_rec *s)
 {
+  mapcache_context *ctx;
+  ctx = (mapcache_context*)create_apache_server_context(s,pool);
   for( ; s ; s=s->next) {
     mapcache_server_cfg* cfg = ap_get_module_config(s->module_config, &mapcache_module);
     int i,rv;
     for(i=0;i<cfg->aliases->nelts;i++) {
       mapcache_alias_entry *alias_entry = APR_ARRAY_IDX(cfg->aliases,i,mapcache_alias_entry*);
+      mapcache_cache_child_init(ctx,alias_entry->cfg,pool);
+      if (GC_HAS_ERROR(ctx)) {
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, ctx->get_error_message(ctx));
+      }
       rv = mapcache_connection_pool_create(alias_entry->cfg, &(alias_entry->cp),pool);
       ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "creating a child process mapcache connection pool on server %s for alias %s", s->server_hostname, alias_entry->endpoint);
       if(rv!=APR_SUCCESS) {
@@ -320,6 +326,10 @@ static void mod_mapcache_child_init(apr_pool_t *pool, server_rec *s)
     }
     for(i=0;i<cfg->quickaliases->nelts;i++) {
       mapcache_alias_entry *alias_entry = APR_ARRAY_IDX(cfg->quickaliases,i,mapcache_alias_entry*);
+      mapcache_cache_child_init(ctx,alias_entry->cfg,pool);
+      if (GC_HAS_ERROR(ctx)) {
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, ctx->get_error_message(ctx));
+      }
       rv = mapcache_connection_pool_create(alias_entry->cfg, &(alias_entry->cp),pool);
       ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "creating a child process mapcache connection pool on server %s for alias %s", s->server_hostname, alias_entry->endpoint);
       if(rv!=APR_SUCCESS) {

--- a/apache/mod_mapcache.c
+++ b/apache/mod_mapcache.c
@@ -316,7 +316,7 @@ static void mod_mapcache_child_init(apr_pool_t *pool, server_rec *s)
       mapcache_alias_entry *alias_entry = APR_ARRAY_IDX(cfg->aliases,i,mapcache_alias_entry*);
       mapcache_cache_child_init(ctx,alias_entry->cfg,pool);
       if (GC_HAS_ERROR(ctx)) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, ctx->get_error_message(ctx));
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, "%s", ctx->get_error_message(ctx));
       }
       rv = mapcache_connection_pool_create(alias_entry->cfg, &(alias_entry->cp),pool);
       ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "creating a child process mapcache connection pool on server %s for alias %s", s->server_hostname, alias_entry->endpoint);
@@ -328,7 +328,7 @@ static void mod_mapcache_child_init(apr_pool_t *pool, server_rec *s)
       mapcache_alias_entry *alias_entry = APR_ARRAY_IDX(cfg->quickaliases,i,mapcache_alias_entry*);
       mapcache_cache_child_init(ctx,alias_entry->cfg,pool);
       if (GC_HAS_ERROR(ctx)) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, ctx->get_error_message(ctx));
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, "%s", ctx->get_error_message(ctx));
       }
       rv = mapcache_connection_pool_create(alias_entry->cfg, &(alias_entry->cp),pool);
       ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "creating a child process mapcache connection pool on server %s for alias %s", s->server_hostname, alias_entry->endpoint);

--- a/cgi/mapcache.c
+++ b/cgi/mapcache.c
@@ -213,6 +213,8 @@ static void load_config(mapcache_context *ctx, char *filename)
     apr_pool_destroy(config_pool);
   }
   config_pool = tmp_config_pool;
+  mapcache_cache_child_init(ctx,cfg,config_pool);
+  if (GC_HAS_ERROR(ctx)) goto failed_load;
   mapcache_connection_pool_create(cfg, &ctx->connection_pool, config_pool);
 
   return;

--- a/contrib/mapcache_detail/mapcache_detail.c
+++ b/contrib/mapcache_detail/mapcache_detail.c
@@ -714,6 +714,8 @@ int main(int argc, char * argv[])
   mapcache_context_init(&ctx);
   ctx.config = mapcache_configuration_create(ctx.pool);
   ctx.log = mapcache_log;
+  mapcache_cache_child_init(&ctx,ctx.config,ctx.pool);
+  if (GC_HAS_ERROR(&ctx)) goto failure;
   mapcache_connection_pool_create(ctx.config, &ctx.connection_pool, ctx.pool);
 
 

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -369,6 +369,7 @@ struct mapcache_cache {
 
   void (*configuration_parse_xml)(mapcache_context *ctx, ezxml_t xml, mapcache_cache * cache, mapcache_cfg *config);
   void (*configuration_post_config)(mapcache_context *ctx, mapcache_cache * cache, mapcache_cfg *config);
+  void (*child_init)(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild);
 };
 
 MS_DLL_EXPORT int mapcache_cache_tile_get(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile);
@@ -376,6 +377,8 @@ void mapcache_cache_tile_delete(mapcache_context *ctx, mapcache_cache *cache, ma
 MS_DLL_EXPORT int mapcache_cache_tile_exists(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile);
 MS_DLL_EXPORT void mapcache_cache_tile_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile);
 void mapcache_cache_tile_multi_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tiles, int ntiles);
+
+MS_DLL_EXPORT void mapcache_cache_child_init(mapcache_context *ctx, mapcache_cfg *config, apr_pool_t *pchild);
 
 
 

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -378,7 +378,7 @@ MS_DLL_EXPORT int mapcache_cache_tile_exists(mapcache_context *ctx, mapcache_cac
 MS_DLL_EXPORT void mapcache_cache_tile_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile);
 void mapcache_cache_tile_multi_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tiles, int ntiles);
 
-void mapcache_cache_child_init(mapcache_context *ctx, mapcache_cfg *config, apr_pool_t *pchild);
+MS_DLL_EXPORT void mapcache_cache_child_init(mapcache_context *ctx, mapcache_cfg *config, apr_pool_t *pchild);
 static inline void mapcache_cache_child_init_noop(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
 };
 

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -378,8 +378,9 @@ MS_DLL_EXPORT int mapcache_cache_tile_exists(mapcache_context *ctx, mapcache_cac
 MS_DLL_EXPORT void mapcache_cache_tile_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tile);
 void mapcache_cache_tile_multi_set(mapcache_context *ctx, mapcache_cache *cache, mapcache_tile *tiles, int ntiles);
 
-MS_DLL_EXPORT void mapcache_cache_child_init(mapcache_context *ctx, mapcache_cfg *config, apr_pool_t *pchild);
-
+void mapcache_cache_child_init(mapcache_context *ctx, mapcache_cfg *config, apr_pool_t *pchild);
+static inline void mapcache_cache_child_init_noop(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
 
 
 /**

--- a/lib/cache.c
+++ b/lib/cache.c
@@ -174,3 +174,16 @@ void mapcache_cache_tile_multi_set(mapcache_context *ctx, mapcache_cache *cache,
     }
   }
 }
+
+void mapcache_cache_child_init(mapcache_context *ctx, mapcache_cfg *config, apr_pool_t *pchild)
+{
+  apr_hash_index_t *cachei = apr_hash_first(pchild,config->caches);
+  while(cachei) {
+    mapcache_cache *cache;
+    const void *key;
+    apr_ssize_t keylen;
+    apr_hash_this(cachei,&key,&keylen,(void**)&cache);
+    cache->child_init(ctx,cache,pchild);
+    cachei = apr_hash_next(cachei);
+  }
+}

--- a/lib/cache_bdb.c
+++ b/lib/cache_bdb.c
@@ -399,6 +399,12 @@ static void _mapcache_cache_bdb_configuration_post_config(mapcache_context *ctx,
 }
 
 /**
+ * \private \memberof mapcache_cache_dbd
+ */
+static void _mapcache_cache_bdb_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
  * \brief creates and initializes a mapcache_dbd_cache
  */
 mapcache_cache* mapcache_cache_bdb_create(mapcache_context *ctx)
@@ -417,6 +423,7 @@ mapcache_cache* mapcache_cache_bdb_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_bdb_multiset;
   cache->cache.configuration_post_config = _mapcache_cache_bdb_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_bdb_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_bdb_child_init;
   cache->basedir = NULL;
   cache->key_template = NULL;
   return (mapcache_cache*)cache;

--- a/lib/cache_bdb.c
+++ b/lib/cache_bdb.c
@@ -399,12 +399,6 @@ static void _mapcache_cache_bdb_configuration_post_config(mapcache_context *ctx,
 }
 
 /**
- * \private \memberof mapcache_cache_dbd
- */
-static void _mapcache_cache_bdb_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_dbd_cache
  */
 mapcache_cache* mapcache_cache_bdb_create(mapcache_context *ctx)
@@ -423,7 +417,7 @@ mapcache_cache* mapcache_cache_bdb_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_bdb_multiset;
   cache->cache.configuration_post_config = _mapcache_cache_bdb_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_bdb_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_bdb_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   cache->basedir = NULL;
   cache->key_template = NULL;
   return (mapcache_cache*)cache;

--- a/lib/cache_composite.c
+++ b/lib/cache_composite.c
@@ -243,12 +243,6 @@ static void _mapcache_cache_composite_configuration_post_config(mapcache_context
 }
 
 /**
- * \private \memberof mapcache_cache_composite
- */
-static void _mapcache_cache_composite_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_cache_composite
  */
 mapcache_cache* mapcache_cache_composite_create(mapcache_context *ctx)
@@ -267,6 +261,6 @@ mapcache_cache* mapcache_cache_composite_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_composite_tile_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_composite_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_composite_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_composite_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   return (mapcache_cache*)cache;
 }

--- a/lib/cache_composite.c
+++ b/lib/cache_composite.c
@@ -242,6 +242,7 @@ static void _mapcache_cache_composite_configuration_post_config(mapcache_context
 {
 }
 
+
 /**
  * \brief creates and initializes a mapcache_cache_composite
  */

--- a/lib/cache_composite.c
+++ b/lib/cache_composite.c
@@ -242,6 +242,11 @@ static void _mapcache_cache_composite_configuration_post_config(mapcache_context
 {
 }
 
+/**
+ * \private \memberof mapcache_cache_composite
+ */
+static void _mapcache_cache_composite_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
 
 /**
  * \brief creates and initializes a mapcache_cache_composite
@@ -262,5 +267,6 @@ mapcache_cache* mapcache_cache_composite_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_composite_tile_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_composite_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_composite_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_composite_child_init;
   return (mapcache_cache*)cache;
 }

--- a/lib/cache_couchbase.c
+++ b/lib/cache_couchbase.c
@@ -449,6 +449,12 @@ static void _mapcache_cache_couchbase_configuration_post_config(mapcache_context
 }
 
 /**
+ * \private \memberof mapcache_cache_couchbase
+ */
+static void _mapcache_cache_couchbase_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
  * \brief creates and initializes a mapcache_couchbase_cache
  */
 mapcache_cache* mapcache_cache_couchbase_create(mapcache_context *ctx) {
@@ -466,6 +472,7 @@ mapcache_cache* mapcache_cache_couchbase_create(mapcache_context *ctx) {
    cache->cache.tile_delete = _mapcache_cache_couchbase_delete;
    cache->cache.configuration_parse_xml = _mapcache_cache_couchbase_configuration_parse_xml;
    cache->cache.configuration_post_config = _mapcache_cache_couchbase_configuration_post_config;
+   cache->cache.child_init = _mapcache_cache_couchbase_child_init;
    cache->host = NULL;
    cache->username = NULL;
    cache->password = NULL;

--- a/lib/cache_couchbase.c
+++ b/lib/cache_couchbase.c
@@ -449,12 +449,6 @@ static void _mapcache_cache_couchbase_configuration_post_config(mapcache_context
 }
 
 /**
- * \private \memberof mapcache_cache_couchbase
- */
-static void _mapcache_cache_couchbase_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_couchbase_cache
  */
 mapcache_cache* mapcache_cache_couchbase_create(mapcache_context *ctx) {
@@ -472,7 +466,7 @@ mapcache_cache* mapcache_cache_couchbase_create(mapcache_context *ctx) {
    cache->cache.tile_delete = _mapcache_cache_couchbase_delete;
    cache->cache.configuration_parse_xml = _mapcache_cache_couchbase_configuration_parse_xml;
    cache->cache.configuration_post_config = _mapcache_cache_couchbase_configuration_post_config;
-   cache->cache.child_init = _mapcache_cache_couchbase_child_init;
+   cache->cache.child_init = mapcache_cache_child_init_noop;
    cache->host = NULL;
    cache->username = NULL;
    cache->password = NULL;

--- a/lib/cache_disk.c
+++ b/lib/cache_disk.c
@@ -748,6 +748,12 @@ static void _mapcache_cache_disk_configuration_post_config(mapcache_context *ctx
 }
 
 /**
+ * \private \memberof mapcache_cache_disk
+ */
+static void _mapcache_cache_disk_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
  * \brief creates and initializes a mapcache_disk_cache
  */
 mapcache_cache* mapcache_cache_disk_create(mapcache_context *ctx)
@@ -768,6 +774,7 @@ mapcache_cache* mapcache_cache_disk_create(mapcache_context *ctx)
   cache->cache._tile_set = _mapcache_cache_disk_set;
   cache->cache.configuration_post_config = _mapcache_cache_disk_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_disk_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_disk_child_init;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_disk.c
+++ b/lib/cache_disk.c
@@ -748,12 +748,6 @@ static void _mapcache_cache_disk_configuration_post_config(mapcache_context *ctx
 }
 
 /**
- * \private \memberof mapcache_cache_disk
- */
-static void _mapcache_cache_disk_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_disk_cache
  */
 mapcache_cache* mapcache_cache_disk_create(mapcache_context *ctx)
@@ -774,7 +768,7 @@ mapcache_cache* mapcache_cache_disk_create(mapcache_context *ctx)
   cache->cache._tile_set = _mapcache_cache_disk_set;
   cache->cache.configuration_post_config = _mapcache_cache_disk_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_disk_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_disk_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_fallback.c
+++ b/lib/cache_fallback.c
@@ -170,6 +170,7 @@ static void _mapcache_cache_fallback_configuration_post_config(mapcache_context 
 {
 }
 
+
 /**
  * \brief creates and initializes a mapcache_cache_fallback
  */

--- a/lib/cache_fallback.c
+++ b/lib/cache_fallback.c
@@ -171,12 +171,6 @@ static void _mapcache_cache_fallback_configuration_post_config(mapcache_context 
 }
 
 /**
- * \private \memberof mapcache_cache_fallback
- */
-static void _mapcache_cache_fallback_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_cache_fallback
  */
 mapcache_cache* mapcache_cache_fallback_create(mapcache_context *ctx)
@@ -195,7 +189,7 @@ mapcache_cache* mapcache_cache_fallback_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_fallback_tile_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_fallback_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_fallback_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_fallback_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_fallback.c
+++ b/lib/cache_fallback.c
@@ -170,6 +170,11 @@ static void _mapcache_cache_fallback_configuration_post_config(mapcache_context 
 {
 }
 
+/**
+ * \private \memberof mapcache_cache_fallback
+ */
+static void _mapcache_cache_fallback_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
 
 /**
  * \brief creates and initializes a mapcache_cache_fallback
@@ -190,6 +195,7 @@ mapcache_cache* mapcache_cache_fallback_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_fallback_tile_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_fallback_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_fallback_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_fallback_child_init;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_memcache.c
+++ b/lib/cache_memcache.c
@@ -352,12 +352,6 @@ static void _mapcache_cache_memcache_configuration_post_config(mapcache_context 
 }
 
 /**
- * \private \memberof mapcache_cache_memcache
- */
-static void _mapcache_cache_memcache_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_memcache_cache
  */
 mapcache_cache* mapcache_cache_memcache_create(mapcache_context *ctx)
@@ -375,7 +369,7 @@ mapcache_cache* mapcache_cache_memcache_create(mapcache_context *ctx)
   cache->cache._tile_delete = _mapcache_cache_memcache_delete;
   cache->cache.configuration_post_config = _mapcache_cache_memcache_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_memcache_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_memcache_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_memcache.c
+++ b/lib/cache_memcache.c
@@ -351,6 +351,7 @@ static void _mapcache_cache_memcache_configuration_post_config(mapcache_context 
   }
 }
 
+
 /**
  * \brief creates and initializes a mapcache_memcache_cache
  */

--- a/lib/cache_memcache.c
+++ b/lib/cache_memcache.c
@@ -351,6 +351,11 @@ static void _mapcache_cache_memcache_configuration_post_config(mapcache_context 
   }
 }
 
+/**
+ * \private \memberof mapcache_cache_memcache
+ */
+static void _mapcache_cache_memcache_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
+};
 
 /**
  * \brief creates and initializes a mapcache_memcache_cache
@@ -370,6 +375,7 @@ mapcache_cache* mapcache_cache_memcache_create(mapcache_context *ctx)
   cache->cache._tile_delete = _mapcache_cache_memcache_delete;
   cache->cache.configuration_post_config = _mapcache_cache_memcache_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_memcache_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_memcache_child_init;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_multitier.c
+++ b/lib/cache_multitier.c
@@ -140,6 +140,7 @@ static void _mapcache_cache_multitier_configuration_post_config(mapcache_context
 {
 }
 
+
 /**
  * \brief creates and initializes a mapcache_cache_multitier
  */

--- a/lib/cache_multitier.c
+++ b/lib/cache_multitier.c
@@ -140,6 +140,11 @@ static void _mapcache_cache_multitier_configuration_post_config(mapcache_context
 {
 }
 
+/**
+ * \private \memberof mapcache_cache_multitier
+ */
+static void _mapcache_cache_multitier_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
 
 /**
  * \brief creates and initializes a mapcache_cache_multitier
@@ -160,6 +165,7 @@ mapcache_cache* mapcache_cache_multitier_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_multitier_tile_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_multitier_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_multitier_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_multitier_child_init;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_multitier.c
+++ b/lib/cache_multitier.c
@@ -141,12 +141,6 @@ static void _mapcache_cache_multitier_configuration_post_config(mapcache_context
 }
 
 /**
- * \private \memberof mapcache_cache_multitier
- */
-static void _mapcache_cache_multitier_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_cache_multitier
  */
 mapcache_cache* mapcache_cache_multitier_create(mapcache_context *ctx)
@@ -165,7 +159,7 @@ mapcache_cache* mapcache_cache_multitier_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_multitier_tile_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_multitier_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_multitier_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_multitier_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   return (mapcache_cache*)cache;
 }
 

--- a/lib/cache_redis.c
+++ b/lib/cache_redis.c
@@ -279,6 +279,12 @@ static void _mapcache_cache_redis_configuration_post_config(mapcache_context *ct
 }
 
 /**
+ * \private \memberof mapcache_cache_redis
+ */
+static void _mapcache_cache_redis_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
  * \brief creates and initializes a mapcache_redis_cache
  */
 mapcache_cache* mapcache_cache_redis_create(mapcache_context *ctx)
@@ -297,6 +303,7 @@ mapcache_cache* mapcache_cache_redis_create(mapcache_context *ctx)
   cache->cache._tile_delete = _mapcache_cache_redis_delete;
   cache->cache.configuration_post_config = _mapcache_cache_redis_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_redis_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_redis_child_init;
   cache->host = NULL;
   cache->port = 6379;
   cache->bucket_template = NULL;

--- a/lib/cache_redis.c
+++ b/lib/cache_redis.c
@@ -279,12 +279,6 @@ static void _mapcache_cache_redis_configuration_post_config(mapcache_context *ct
 }
 
 /**
- * \private \memberof mapcache_cache_redis
- */
-static void _mapcache_cache_redis_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_redis_cache
  */
 mapcache_cache* mapcache_cache_redis_create(mapcache_context *ctx)
@@ -303,7 +297,7 @@ mapcache_cache* mapcache_cache_redis_create(mapcache_context *ctx)
   cache->cache._tile_delete = _mapcache_cache_redis_delete;
   cache->cache.configuration_post_config = _mapcache_cache_redis_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_redis_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_redis_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   cache->host = NULL;
   cache->port = 6379;
   cache->bucket_template = NULL;

--- a/lib/cache_rest.c
+++ b/lib/cache_rest.c
@@ -1426,6 +1426,12 @@ static void _mapcache_cache_rest_configuration_post_config(mapcache_context *ctx
   }
 }
 
+/**
+ * \private \memberof mapcache_cache_rest
+ */
+static void _mapcache_cache_rest_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
 void mapcache_cache_rest_init(mapcache_context *ctx, mapcache_cache_rest *cache) {
   cache->use_redirects = 0;
   cache->rest.get_tile.method = MAPCACHE_REST_METHOD_GET;
@@ -1441,6 +1447,7 @@ void mapcache_cache_rest_init(mapcache_context *ctx, mapcache_cache_rest *cache)
   cache->cache._tile_set = _mapcache_cache_rest_set;
   cache->cache.configuration_post_config = _mapcache_cache_rest_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_rest_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_rest_child_init;
 }
 /**
  * \brief creates and initializes a mapcache_rest_cache

--- a/lib/cache_rest.c
+++ b/lib/cache_rest.c
@@ -1426,12 +1426,6 @@ static void _mapcache_cache_rest_configuration_post_config(mapcache_context *ctx
   }
 }
 
-/**
- * \private \memberof mapcache_cache_rest
- */
-static void _mapcache_cache_rest_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
 void mapcache_cache_rest_init(mapcache_context *ctx, mapcache_cache_rest *cache) {
   cache->use_redirects = 0;
   cache->rest.get_tile.method = MAPCACHE_REST_METHOD_GET;
@@ -1447,7 +1441,7 @@ void mapcache_cache_rest_init(mapcache_context *ctx, mapcache_cache_rest *cache)
   cache->cache._tile_set = _mapcache_cache_rest_set;
   cache->cache.configuration_post_config = _mapcache_cache_rest_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_rest_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_rest_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
 }
 /**
  * \brief creates and initializes a mapcache_rest_cache

--- a/lib/cache_riak.c
+++ b/lib/cache_riak.c
@@ -407,12 +407,6 @@ static void _mapcache_cache_riak_configuration_post_config(mapcache_context *ctx
 }
 
 /**
- * \private \memberof mapcache_cache_riak
- */
-static void _mapcache_cache_riak_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_riak_cache
  */
 mapcache_cache* mapcache_cache_riak_create(mapcache_context *ctx) {
@@ -430,7 +424,7 @@ mapcache_cache* mapcache_cache_riak_create(mapcache_context *ctx) {
     cache->cache._tile_delete = _mapcache_cache_riak_delete;
     cache->cache.configuration_parse_xml = _mapcache_cache_riak_configuration_parse_xml;
     cache->cache.configuration_post_config = _mapcache_cache_riak_configuration_post_config;
-    cache->cache.child_init = _mapcache_cache_riak_child_init;
+    cache->cache.child_init = mapcache_cache_child_init_noop;
     cache->host = NULL;
     cache->port = 8087;	// Default RIAK port used for protobuf
     cache->bucket_template = NULL;

--- a/lib/cache_riak.c
+++ b/lib/cache_riak.c
@@ -407,6 +407,12 @@ static void _mapcache_cache_riak_configuration_post_config(mapcache_context *ctx
 }
 
 /**
+ * \private \memberof mapcache_cache_riak
+ */
+static void _mapcache_cache_riak_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
  * \brief creates and initializes a mapcache_riak_cache
  */
 mapcache_cache* mapcache_cache_riak_create(mapcache_context *ctx) {
@@ -424,6 +430,7 @@ mapcache_cache* mapcache_cache_riak_create(mapcache_context *ctx) {
     cache->cache._tile_delete = _mapcache_cache_riak_delete;
     cache->cache.configuration_parse_xml = _mapcache_cache_riak_configuration_parse_xml;
     cache->cache.configuration_post_config = _mapcache_cache_riak_configuration_post_config;
+    cache->cache.child_init = _mapcache_cache_riak_child_init;
     cache->host = NULL;
     cache->port = 8087;	// Default RIAK port used for protobuf
     cache->bucket_template = NULL;

--- a/lib/cache_sqlite.c
+++ b/lib/cache_sqlite.c
@@ -1041,12 +1041,6 @@ static void _mapcache_cache_sqlite_configuration_post_config(mapcache_context *c
 /**
  * \private \memberof mapcache_cache_sqlite
  */
-static void _mapcache_cache_sqlite_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
- * \private \memberof mapcache_cache_sqlite
- */
 static void _mapcache_cache_mbtiles_configuration_post_config(mapcache_context *ctx,
     mapcache_cache *pcache, mapcache_cfg *cfg)
 {
@@ -1076,12 +1070,6 @@ static void _mapcache_cache_mbtiles_configuration_post_config(mapcache_context *
 #endif
 }
 
-/**
- * \private \memberof mapcache_cache_sqlite
- */
-static void _mapcache_cache_mbtiles_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
 mapcache_cache* mapcache_cache_sqlite_create(mapcache_context *ctx)
 {
   mapcache_cache_sqlite *cache = apr_pcalloc(ctx->pool, sizeof (mapcache_cache_sqlite));
@@ -1098,7 +1086,7 @@ mapcache_cache* mapcache_cache_sqlite_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_sqlite_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_sqlite_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_sqlite_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_sqlite_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   cache->create_stmt.sql = apr_pstrdup(ctx->pool,
                                        "create table if not exists tiles(tileset text, grid text, x integer, y integer, z integer, data blob, dim text, ctime datetime, primary key(tileset,grid,x,y,z,dim))");
   cache->exists_stmt.sql = apr_pstrdup(ctx->pool,
@@ -1134,7 +1122,7 @@ mapcache_cache* mapcache_cache_mbtiles_create(mapcache_context *ctx)
     return NULL;
   }
   cache->cache.configuration_post_config = _mapcache_cache_mbtiles_configuration_post_config;
-  cache->cache.child_init = _mapcache_cache_mbtiles_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   cache->cache._tile_set = _mapcache_cache_mbtiles_set;
   cache->cache._tile_multi_set = _mapcache_cache_mbtiles_multi_set;
   cache->cache._tile_delete = _mapcache_cache_mbtiles_delete;

--- a/lib/cache_sqlite.c
+++ b/lib/cache_sqlite.c
@@ -1041,6 +1041,12 @@ static void _mapcache_cache_sqlite_configuration_post_config(mapcache_context *c
 /**
  * \private \memberof mapcache_cache_sqlite
  */
+static void _mapcache_cache_sqlite_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
+ * \private \memberof mapcache_cache_sqlite
+ */
 static void _mapcache_cache_mbtiles_configuration_post_config(mapcache_context *ctx,
     mapcache_cache *pcache, mapcache_cfg *cfg)
 {
@@ -1070,6 +1076,12 @@ static void _mapcache_cache_mbtiles_configuration_post_config(mapcache_context *
 #endif
 }
 
+/**
+ * \private \memberof mapcache_cache_sqlite
+ */
+static void _mapcache_cache_mbtiles_child_init(mapcache_context *ctx, mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
 mapcache_cache* mapcache_cache_sqlite_create(mapcache_context *ctx)
 {
   mapcache_cache_sqlite *cache = apr_pcalloc(ctx->pool, sizeof (mapcache_cache_sqlite));
@@ -1086,6 +1098,7 @@ mapcache_cache* mapcache_cache_sqlite_create(mapcache_context *ctx)
   cache->cache._tile_multi_set = _mapcache_cache_sqlite_multi_set;
   cache->cache.configuration_post_config = _mapcache_cache_sqlite_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_sqlite_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_sqlite_child_init;
   cache->create_stmt.sql = apr_pstrdup(ctx->pool,
                                        "create table if not exists tiles(tileset text, grid text, x integer, y integer, z integer, data blob, dim text, ctime datetime, primary key(tileset,grid,x,y,z,dim))");
   cache->exists_stmt.sql = apr_pstrdup(ctx->pool,
@@ -1121,6 +1134,7 @@ mapcache_cache* mapcache_cache_mbtiles_create(mapcache_context *ctx)
     return NULL;
   }
   cache->cache.configuration_post_config = _mapcache_cache_mbtiles_configuration_post_config;
+  cache->cache.child_init = _mapcache_cache_mbtiles_child_init;
   cache->cache._tile_set = _mapcache_cache_mbtiles_set;
   cache->cache._tile_multi_set = _mapcache_cache_mbtiles_multi_set;
   cache->cache._tile_delete = _mapcache_cache_mbtiles_delete;

--- a/lib/cache_tiff.c
+++ b/lib/cache_tiff.c
@@ -1380,12 +1380,6 @@ static void _mapcache_cache_tiff_configuration_post_config(mapcache_context *ctx
 }
 
 /**
- * \private \memberof mapcache_cache_tiff
- */
-static void _mapcache_cache_tiff_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
-/**
  * \brief creates and initializes a mapcache_tiff_cache
  */
 mapcache_cache* mapcache_cache_tiff_create(mapcache_context *ctx)
@@ -1403,7 +1397,7 @@ mapcache_cache* mapcache_cache_tiff_create(mapcache_context *ctx)
   cache->cache._tile_set = _mapcache_cache_tiff_set;
   cache->cache.configuration_post_config = _mapcache_cache_tiff_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_tiff_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_tiff_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   cache->count_x = 10;
   cache->count_y = 10;
   cache->x_fmt = cache->y_fmt = cache->z_fmt

--- a/lib/cache_tiff.c
+++ b/lib/cache_tiff.c
@@ -1380,6 +1380,12 @@ static void _mapcache_cache_tiff_configuration_post_config(mapcache_context *ctx
 }
 
 /**
+ * \private \memberof mapcache_cache_tiff
+ */
+static void _mapcache_cache_tiff_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
+/**
  * \brief creates and initializes a mapcache_tiff_cache
  */
 mapcache_cache* mapcache_cache_tiff_create(mapcache_context *ctx)
@@ -1397,6 +1403,7 @@ mapcache_cache* mapcache_cache_tiff_create(mapcache_context *ctx)
   cache->cache._tile_set = _mapcache_cache_tiff_set;
   cache->cache.configuration_post_config = _mapcache_cache_tiff_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_tiff_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_tiff_child_init;
   cache->count_x = 10;
   cache->count_y = 10;
   cache->x_fmt = cache->y_fmt = cache->z_fmt

--- a/lib/cache_tokyocabinet.c
+++ b/lib/cache_tokyocabinet.c
@@ -201,6 +201,9 @@ static void _mapcache_cache_tc_configuration_post_config(mapcache_context *ctx,
   }
 }
 
+static void _mapcache_cache_tc_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
+};
+
 /**
  * \brief creates and initializes a mapcache_dbd_cache
  */
@@ -219,6 +222,7 @@ mapcache_cache* mapcache_cache_tc_create(mapcache_context *ctx)
   cache->cache.tile_set = _mapcache_cache_tc_set;
   cache->cache.configuration_post_config = _mapcache_cache_tc_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_tc_configuration_parse_xml;
+  cache->cache.child_init = _mapcache_cache_tc_child_init;
   cache->basedir = NULL;
   cache->key_template = NULL;
   return (mapcache_cache*)cache;

--- a/lib/cache_tokyocabinet.c
+++ b/lib/cache_tokyocabinet.c
@@ -201,9 +201,6 @@ static void _mapcache_cache_tc_configuration_post_config(mapcache_context *ctx,
   }
 }
 
-static void _mapcache_cache_tc_child_init(mapcache_cache *cache, apr_pool_t *pchild) {
-};
-
 /**
  * \brief creates and initializes a mapcache_dbd_cache
  */
@@ -222,7 +219,7 @@ mapcache_cache* mapcache_cache_tc_create(mapcache_context *ctx)
   cache->cache.tile_set = _mapcache_cache_tc_set;
   cache->cache.configuration_post_config = _mapcache_cache_tc_configuration_post_config;
   cache->cache.configuration_parse_xml = _mapcache_cache_tc_configuration_parse_xml;
-  cache->cache.child_init = _mapcache_cache_tc_child_init;
+  cache->cache.child_init = mapcache_cache_child_init_noop;
   cache->basedir = NULL;
   cache->key_template = NULL;
   return (mapcache_cache*)cache;

--- a/nginx/ngx_http_mapcache_module.c
+++ b/nginx/ngx_http_mapcache_module.c
@@ -300,6 +300,11 @@ ngx_http_mapcache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "no mapcache <service>s configured/enabled, no point in continuing.");
     return NGX_CONF_ERROR;
   }
+  mapcache_cache_child_init(ctx,ctx->cfg,ctx->pool);
+  if(GC_HAS_ERROR(ctx)) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,ctx->get_error_message(ctx));
+    return NGX_CONF_ERROR;
+  }
   mapcache_connection_pool_create(ctx->config, &ctx->connection_pool,ctx->pool);
   ctx->config->non_blocking = 1;
 

--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -1189,6 +1189,9 @@ int main(int argc, const char **argv)
     mapcache_configuration_post_config(&ctx,cfg);
     if(ctx.get_error(&ctx))
       return usage(argv[0],ctx.get_error_message(&ctx));
+    mapcache_cache_child_init(&ctx,cfg,ctx.pool);
+    if (GC_HAS_ERROR(&ctx))
+      return usage(argv[0],ctx.get_error_message(&ctx));
     mapcache_connection_pool_create(cfg, &ctx.connection_pool, ctx.pool);
   }
 


### PR DESCRIPTION
Depending on a cache backend in use it might be necessary to perform some kind of initialization when a server worker process starts. In the case of Apache (MPM event) the child_init hook runs after a process has been created (forked) and before serving threads have been created. Currently this child_init hook is not exposed directly to cache backends and it is used only to set up connection pool. This PR adds a child_init hook for usage in any cache backend. At the moment there are no backends using this hook, although it might be required for (probably) Berkeley and (quite certainly) for TokyoCabinet backends. A LMDB cache backend requiring this hook is now under testing.