### PR TITLE
Remove C89 restriction for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror=declaration-after-statement -std=c89 -Wno-comment")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror=declaration-after-statement -Wno-comment")
 endif()
 
 #options suported by the cmake builder


### PR DESCRIPTION
The limitation of C89 was introduced for MSVC compatibility in PR #129 but at the same time MapServer has bumped up to C99 https://mapserver.org/development/rfc/ms-rfc-128.html