### PR TITLE
mapcache_seed: try to kill still running threads after grace period

### DIFF
--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -495,6 +495,7 @@ void cmd_recurse(mapcache_context *cmd_ctx, mapcache_tile *tile)
       if (ret != APR_SUCCESS)
         retry_count++;
       if (retry_count > 10) {
+        printf("Feed worker threads failed to terminate. Stopping forcefully.\n");
         apr_queue_interrupt_all(work_queue);
         break;
       }
@@ -639,6 +640,7 @@ void feed_worker()
           if (ret != APR_SUCCESS)
             retry_count++;
           if (retry_count > 10) {
+            printf("Feed worker threads failed to terminate. Stopping forcefully.\n");
             apr_queue_interrupt_all(work_queue);
             break;
           }

--- a/util/mapcache_seed.c
+++ b/util/mapcache_seed.c
@@ -616,13 +616,14 @@ void feed_worker()
         struct seed_cmd entry;
         int retry = 0;
         while (trypop_queue(&entry)!=APR_EAGAIN) {
-            // threads can be stuck
-            retry++;
-            if (retry > 10) {
-                apr_queue_interrupt_all(&entry);
-                break;
-            }
-            apr_sleep(retry * 1000000);
+          // threads can be stuck
+          retry++;
+          if (retry > 10) {
+            apr_queue_interrupt_all(&entry);
+            break;
+          }
+          // graceful retreat up to 55 seconds in total
+          apr_sleep(retry * 1000000);
         }
         break;
       }


### PR DESCRIPTION
On rare occasions a seeding thread might be stuck (e.g. deadlocked). In a such case seeder process can not finish at all as it would wait for thread to complete forever.

This PR waits for the thread to finish ten times with increasing waiting time till 55 seconds in total have passed and then proceeds to terminate all remaining threads.

Questions to discuss:
* should there be a warning logged/printed?
* are 55 seconds of grace time enough?