### PR TITLE
Allow to provide custom Cache-Control header values (fixes #322)

### DIFF
--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1200,7 +1200,7 @@ struct mapcache_tileset {
   int auto_expire;
 
   /**
-   * Cache-Control directives to be set for a TMS response
+   * Cache-Control directives to be set for a tiled response (MAPCACHE_REQUEST_GET_TILE)
    *
    * complements expiration set by the #expires parameter.
    * \sa expires

--- a/include/mapcache.h
+++ b/include/mapcache.h
@@ -1199,6 +1199,14 @@ struct mapcache_tileset {
    */
   int auto_expire;
 
+  /**
+   * Cache-Control directives to be set for a TMS response
+   *
+   * complements expiration set by the #expires parameter.
+   * \sa expires
+   */
+  const char *cache_control;
+
   int read_only;
   int subdimension_read_only;
 

--- a/lib/configuration_xml.c
+++ b/lib/configuration_xml.c
@@ -1163,6 +1163,11 @@ void parseTileset(mapcache_context *ctx, ezxml_t node, mapcache_cfg *config)
     }
   }
 
+  tileset->cache_control = NULL;
+  if ((cur_node = ezxml_child(node,"cache-control")) != NULL) {
+    tileset->cache_control = apr_pstrdup(ctx->pool, cur_node->txt);
+  }
+
   if ((cur_node = ezxml_child(node,"metabuffer")) != NULL) {
     char *endptr;
     tileset->metabuffer = (int)strtol(cur_node->txt,&endptr,10);

--- a/lib/core.c
+++ b/lib/core.c
@@ -346,10 +346,21 @@ mapcache_http_response *mapcache_core_get_tile(mapcache_context *ctx, mapcache_r
     apr_time_t now = apr_time_now();
     apr_time_t additional = apr_time_from_sec(expires);
     apr_time_t texpires = now + additional;
-    apr_table_set(response->headers, "Cache-Control",apr_psprintf(ctx->pool, "max-age=%d", expires));
     timestr = apr_palloc(ctx->pool, APR_RFC822_DATE_LEN);
     apr_rfc822_date(timestr, texpires);
     apr_table_setn(response->headers, "Expires", timestr);
+  }
+  if (expires || req_tile->tiles[0]->tileset->cache_control) {
+    apr_table_set(
+        response->headers, "Cache-Control",
+        apr_pstrcat(
+            ctx->pool,
+            expires ? apr_psprintf(ctx->pool, "max-age=%d", expires) : "",
+            expires && req_tile->tiles[0]->tileset->cache_control ? ", " : "",
+            req_tile->tiles[0]->tileset->cache_control
+                ? req_tile->tiles[0]->tileset->cache_control
+                : "",
+            NULL));
   }
 
   return response;


### PR DESCRIPTION
This PR allows user to specify custom Cache-Control HTTP header values on a tileset basis.
As caching of WMS responses makes little sense, implemented only for TMS.