### PR TITLE
handle uint64_t redefinition error on Windows

### DIFF
--- a/lib/imageio_png.c
+++ b/lib/imageio_png.c
@@ -33,10 +33,7 @@
 #include <apr_strings.h>
 
 #ifdef _WIN32
-typedef unsigned char     uint8_t;
-typedef unsigned short    uint16_t;
-typedef unsigned int      uint32_t;
-typedef unsigned long int uint64_t;
+#include <stdint.h>
 #endif
 
 #ifndef Z_BEST_SPEED

--- a/lib/util.c
+++ b/lib/util.c
@@ -45,10 +45,7 @@
 #endif
 
 #ifdef _WIN32
-typedef unsigned char     uint8_t;
-typedef unsigned short    uint16_t;
-typedef unsigned int      uint32_t;
-typedef unsigned long int uint64_t;
+#include <stdint.h>
 #endif
 
 const double mapcache_meters_per_unit[MAPCACHE_UNITS_COUNT] = {1.0,6378137.0 * 2.0 * M_PI / 360,0.3048};


### PR DESCRIPTION
- recent Visual Studio versions throw errors such as:
  `mapcache\lib\util.c(51,27): error C2371: 'uint64_t': redefinition; different basic types`
- this PR leverages `stdint.h`, which has been available in Visual Studio since v2010

discovered through https://github.com/MapServer/mapcache/pull/339