### PR TITLE
Update CI to Windows Server 2022 and VS 2022

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,7 +6,7 @@ jobs:
     build-matrix:
       strategy:
         matrix:
-          os: [ windows-2019 ]
+          os: [ windows-2022 ]
           option: [ default ]
       runs-on: ${{matrix.os}}
       steps:
@@ -18,9 +18,9 @@ jobs:
             Set-Location -Path "${{github.workspace}}"
             New-Item -Path . -Name "sdk" -ItemType "directory"
             Set-Location -Path "sdk"
-            curl -O https://download.gisinternals.com/sdk/downloads/release-1928-x64-dev.zip
-            unzip -qq release-1928-x64-dev.zip
-            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            curl -O https://download.gisinternals.com/sdk/downloads/release-1930-x64-dev.zip
+            unzip -qq release-1930-x64-dev.zip
+            $sdkprefix = "${{github.workspace}}\sdk\release-1930-x64"
             Set-Location -Path "$sdkprefix\lib"
             Copy-Item -Path "libfcgi.lib" -Destination "fcgi.lib"
             Copy-Item -Path "apr-1.lib" -Destination "apr-1-1.lib"
@@ -30,7 +30,7 @@ jobs:
 
         - name: Build MapCache
           run: |
-            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            $sdkprefix = "${{github.workspace}}\sdk\release-1930-x64"
             Set-Location -Path "${{github.workspace}}"
             New-Item -Path . -Name "build" -ItemType "directory"
             Set-Location -Path "build"
@@ -49,7 +49,7 @@ jobs:
 
         - name: Setup tests
           run: |
-            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            $sdkprefix = "${{github.workspace}}\sdk\release-1930-x64"
             Set-Location -Path "${{github.workspace}}\build"
             Copy-Item -Path "..\tests\data\world.tif" -Destination .
             New-Item -Path "mapcache.xml"
@@ -80,7 +80,7 @@ jobs:
 
         - name: Run tests
           run: |
-            $sdkprefix = "${{github.workspace}}\sdk\release-1928-x64"
+            $sdkprefix = "${{github.workspace}}\sdk\release-1930-x64"
             Set-Location -Path "$sdkprefix\bin"
             $env:GDAL_DATA = "$sdkprefix\bin\gdal-data"
             $env:PROJ_LIB = "$sdkprefix\bin\proj9\share"


### PR DESCRIPTION
Windows Server 2019 will be removed at the end of the month, see CI messages in https://github.com/MapServer/mapcache/actions/runs/15852001443

```
build-matrix (windows-2019, default)
This is a scheduled Windows Server 2019 brownout. The Windows Server 2019 image will be removed on 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
```

This updates to Windows Server 2022 and VS 2022 and the corresponding SDK from www.gisinternals.com